### PR TITLE
Fix draft arguments

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -10,6 +10,7 @@ const post = defineCollection({
     categories: z.array(z.string()).default(['others']),
     tags: z.array(z.string()).default(['others']),
     authors: z.array(z.any()).default(['team']),
+    draft: z.boolean().default(false),
   }),
 });
 

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -6,7 +6,9 @@ import Pagination from "@components/Pagination.astro";
 import config from "@config/config.json";
 
 export async function getStaticPaths({ paginate }) {
-  const allPosts = await getCollection("post");
+  const allPosts = await getCollection('post', ({ data }) => {
+    return data.draft !== true;
+  });
   const formattedPosts = allPosts.sort(
     (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
   );


### PR DESCRIPTION
Allows the `draft: true` argument to be parsed for disabling certain blog posts from being published.