### PR TITLE
Fix SPARQL query to match with Cypher query

### DIFF
--- a/src/content/post/2024-05-14-rdf-shacl-and-kuzu.md
+++ b/src/content/post/2024-05-14-rdf-shacl-and-kuzu.md
@@ -362,8 +362,10 @@ The above Cypher query is functionally equivalent to this SPARQL query that can 
 PREFIX kz: <http://kuzu.io/rdf-ex#>
 SELECT DISTINCT ?src ?name
 WHERE {
-  ?src a kz:student .
-  ?src kz:name ?name .
+    ?src a kz:student .
+    ?src kz:name ?name .
+    FILTER(?name = "Karissa")
+}
 ```
 
 Both queries would return the same result:


### PR DESCRIPTION
Makes the SPARQL query return identical results to the Cypher equivalent (a filter clause was missing).