### PR TITLE
Update Kùzu to Kuzu across blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Kùzu Blog
+# Kuzu Blog
 
-Code for Kùzu's blog site, built with [Astro](https://astro.build/), Tailwind CSS, and TypeScript.
+Code for Kuzu's blog site, built with [Astro](https://astro.build/), Tailwind CSS, and TypeScript.
 The site is built on top of the [EV0](https://github.com/gndx/ev0-astro-theme) OSS theme.
 
 ## 🚀 Getting Started
@@ -32,14 +32,14 @@ To configure the blog, edit the `src/config/config.json` file. This file contain
 ```scheme
 {
   "site": {
-    "title": "Blog - Kùzu",
+    "title": "Blog - Kuzu",
     "base_url": "blog.kuzudb.com",
     "base_path": "/",
     "favicon": "/favicon.ico",
     "logoLight": "/logoLight.png",
     "logoDark": "/logoDark.png",
     "lang": "en",
-    "description": "Kùzu is a highly scalable, extremely fast, easy-to-use embeddable graph database",
+    "description": "Kuzu is a highly scalable, extremely fast, easy-to-use embeddable graph database",
     "pageSize": 6
   },
   "features": {
@@ -48,11 +48,11 @@ To configure the blog, edit the `src/config/config.json` file. This file contain
   },
   "metadata": {
     "meta_author": "Kùzu Inc.",
-    "meta_description": "Kùzu is a highly scalable, extremely fast, easy-to-use embeddable graph database"
+    "meta_description": "Kuzu is a highly scalable, extremely fast, easy-to-use embeddable graph database"
   },
   "blog_description": {
-    "heading": "Welcome to the Kùzu blog",
-    "bio": "Kùzu is a highly scalable, extremely fast, easy-to-use embeddable graph database."
+    "heading": "Welcome to the Kuzu blog",
+    "bio": "Kuzu is a highly scalable, extremely fast, easy-to-use embeddable graph database."
   },
 }
 ```

--- a/src/config/allAuthors.json
+++ b/src/config/allAuthors.json
@@ -1,6 +1,6 @@
 {
   "team": {
-    "name": "Kùzu Team",
+    "name": "Kuzu Team",
     "image": "https://kuzudb.com/favicon-32x32.png",
     "bio": "Developers of Kùzu Inc."
   },

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -1,13 +1,13 @@
 {
   "site": {
-    "title": "Blog - Kùzu",
+    "title": "Blog - Kuzu",
     "base_url": "https://blog.kuzudb.com",
     "base_path": "/",
     "favicon": "/favicon.ico",
     "logoLight": "/logoLight.png",
     "logoDark": "/logoDark.png",
     "lang": "en",
-    "description": "Kùzu is a highly scalable, extremely fast, easy-to-use embeddable graph database",
+    "description": "Kuzu is a highly scalable, extremely fast, easy-to-use embeddable graph database",
     "pageSize": 6
   },
   "features": {
@@ -16,15 +16,15 @@
   },
   "metadata": {
     "meta_author": "Kùzu Inc.",
-    "meta_description": "Kùzu is a highly scalable, extremely fast, easy-to-use embeddable graph database"
+    "meta_description": "Kuzu is a highly scalable, extremely fast, easy-to-use embeddable graph database"
   },
   "blog_description": {
     "heading": "Blog",
-    "bio": "Kùzu is a highly scalable, extremely fast, embeddable property graph database management system."
+    "bio": "Kuzu is a highly scalable, extremely fast, embeddable property graph database management system."
   },
   "author": {
-    "name": "Kùzu Team",
-    "title": "Kùzu Team",
+    "name": "Kuzu Team",
+    "title": "Kuzu Team",
     "avatar": "https://kuzudb.com/img/blog/team.jpg"
   }
 }

--- a/src/config/youtube.json
+++ b/src/config/youtube.json
@@ -1,7 +1,7 @@
 [
   {
-    "title": "3 Ways to Interact with Kùzu",
-    "description": "In this video, Prashanth Rao, AI Engineer at Kùzu Inc. discusses 3 common ways to interact with Kùzu: the client API, the ...",
+    "title": "3 Ways to Interact with Kuzu",
+    "description": "In this video, Prashanth Rao, AI Engineer at Kùzu Inc. discusses 3 common ways to interact with Kuzu: the client API, the ...",
     "channelId": "UC3kFBpnMVI9aEs-TUiFcb4g",
     "channelTitle": "KùzuDB",
     "videoId": "wV2iphFc_f0",
@@ -75,8 +75,8 @@
     "publishedAt": "2024-05-30T18:45:59Z"
   },
   {
-    "title": "Kùzu user meeting - February 27 2024",
-    "description": "This is the recording of the fourth Kùzu user meeting. We discussed the new features from the v0.0.12 release up until the v0.2.0 ...",
+    "title": "Kuzu user meeting - February 27 2024",
+    "description": "This is the recording of the fourth Kuzu user meeting. We discussed the new features from the v0.0.12 release up until the v0.2.0 ...",
     "channelId": "UC3kFBpnMVI9aEs-TUiFcb4g",
     "channelTitle": "KùzuDB",
     "videoId": "1SoqVJLy5vQ",
@@ -100,8 +100,8 @@
     "publishedAt": "2024-02-28T18:45:34Z"
   },
   {
-    "title": "Kùzu user meeting - November 22 2023",
-    "description": "This is the recording of the third Kùzu user meeting. We discussed the new features from the v0.0.7 release up until the v0.1.0 ...",
+    "title": "Kuzu user meeting - November 22 2023",
+    "description": "This is the recording of the third Kuzu user meeting. We discussed the new features from the v0.0.7 release up until the v0.1.0 ...",
     "channelId": "UC3kFBpnMVI9aEs-TUiFcb4g",
     "channelTitle": "KùzuDB",
     "videoId": "-L0mMPSQOsk",

--- a/src/content/post/2022-11-15-meet-kuzu.md
+++ b/src/content/post/2022-11-15-meet-kuzu.md
@@ -1,7 +1,7 @@
 ---
 slug: "meet-kuzu"
-title: "Meet Kùzu 🤗"
-description: "Kùzu is a new embeddable property graph database management system (GDBMS) that is 
+title: "Meet Kuzu 🤗"
+description: "Kuzu is a new embeddable property graph database management system (GDBMS) that is 
 designed for high scalability and very fast querying"
 pubDate: "Nov 15 2022"
 heroImage: "/img/default.png"
@@ -10,22 +10,22 @@ authors: ["team"]
 tags: ["vision"]
 ---
 
-Today we are very excited to make an initial version of [Kùzu public on github](https://github.com/kuzudb/kuzu)! 
-Kùzu[^1] is a new embeddable property graph database management system (GDBMS) that is 
+Today we are very excited to make an initial version of [Kuzu public on github](https://github.com/kuzudb/kuzu)! 
+Kuzu[^1] is a new embeddable property graph database management system (GDBMS) that is 
 designed for high scalability and very fast querying. We are releasing 
-Kùzu today under a permissible MIT license. Through years of research on GDBMSs, we observed a lack of
+Kuzu today under a permissible MIT license. Through years of research on GDBMSs, we observed a lack of
 highly efficient GDBMS in the market that adopts state-of-the-art 
 querying and storage techniques and that can very easily integrate into applications, 
-similar to DuckDB or SQLite. Kùzu aims to fill this space and evolve into the 
+similar to DuckDB or SQLite. Kuzu aims to fill this space and evolve into the 
 go-to open-source system to develop
 graph database applications, e.g., to manage and query your knowledge graphs, 
 and develop graph machine learning and analytics pipelines, 
 e.g., in the Python data science ecosystem. 
 
-Kùzu's core architecture is informed by 6 years of research we conducted 
+Kuzu's core architecture is informed by 6 years of research we conducted 
 at University of Waterloo on an earlier prototype GDBMS called [GraphflowDB](http://graphflow.io/). 
-Unlike GraphflowDB, which was intended to be a prototype for our research, Kùzu aims to be
-a usable feature-rich system. Some of the primary features of Kùzu's architecture are:
+Unlike GraphflowDB, which was intended to be a prototype for our research, Kuzu aims to be
+a usable feature-rich system. Some of the primary features of Kuzu's architecture are:
 
 - Flexible Property Graph Data Model and Cypher query language
 - Embeddable, serverless integration into applications
@@ -46,10 +46,10 @@ You can also read more about some of our longer term goals and vision as a syste
 in [our new CIDR 2023 paper](https://cs.uwaterloo.ca/~ssalihog/papers/kuzu-tr.pdf), 
 which we will present in Amsterdam next January. 
 
-*And most importantly please start using Kùzu, tell us your feature requests, use cases, and report bugs. We can evolve into a
+*And most importantly please start using Kuzu, tell us your feature requests, use cases, and report bugs. We can evolve into a
 more stable, usable, and feature-rich system only through your feedback!* 
 
-We are looking forward to to your feedback and a long and exciting journey as we continue developing Kùzu 🤗. 
+We are looking forward to to your feedback and a long and exciting journey as we continue developing Kuzu 🤗. 
 
 ---
 

--- a/src/content/post/2023-01-12-what-every-gdbms-should-do.md
+++ b/src/content/post/2023-01-12-what-every-gdbms-should-do.md
@@ -1,7 +1,7 @@
 ---
 slug: "what-every-gdbms-should-do-and-vision"
-title: "What every competent GDBMS should do (a.k.a. the goals and vision of Kùzu)"
-description: "What every competent GDBMS should do (a.k.a. the goals and vision of Kùzu)"
+title: "What every competent GDBMS should do (a.k.a. the goals and vision of Kuzu)"
+description: "What every competent GDBMS should do (a.k.a. the goals and vision of Kuzu)"
 pubDate: "Jan 12 2023"
 heroImage: "/img/2023-01-12-what-every-gdbms-should-do/bachmann.png"
 categories: ["concept"]
@@ -9,7 +9,7 @@ authors: ["semih"]
 tags: ["vision"]
 ---
 
-As a co-implementer of the Kùzu GDBMS and
+As a co-implementer of the Kuzu GDBMS and
 a professor at the University of Waterloo,
 I have been thinking of GDBMSs day in and day out for many years now.
 After years of understanding and publishing on the architectural principles 
@@ -18,9 +18,9 @@ of graph data management ([1](http://www.vldb.org/pvldb/vol12/p1692-mhedhbi.pdf)
 [3](https://www.vldb.org/pvldb/vol15/p1011-jin.pdf),
 [4](https://www.vldb.org/pvldb/vol15/p1533-chen.pdf)),
 we decided to develop 
-[Kùzu](https://github.com/kuzudb/kuzu) as a state-of-the-art modern embeddable GDBMS. 
+[Kuzu](https://github.com/kuzudb/kuzu) as a state-of-the-art modern embeddable GDBMS. 
 This post covers my broad opinions on GDBMSs, and the feature set they should
-optimize for and why. In doing so, it also gives an overall vision of Kùzu, so let's gear up!
+optimize for and why. In doing so, it also gives an overall vision of Kuzu, so let's gear up!
 
 ---
 
@@ -40,20 +40,20 @@ features/use cases that RDBMSs do not traditionally optimize for: (i) pre-define
 (iv) schema querying; 
 (v) efficient storage of semi-structured data and URIs.
 GDBMSs that want to be competitive in terms of performance
-need to perfect this feature set and that's exactly what Kùzu aims to do!
+need to perfect this feature set and that's exactly what Kuzu aims to do!
 
-- **Kùzu as the GDBMS for Graph Data Science**: 
-One example application domain the Kùzu team is excited about is 
+- **Kuzu as the GDBMS for Graph Data Science**: 
+One example application domain the Kuzu team is excited about is 
 to be a usable, efficient, and scalable GDBMS of graph data science in the Python graph analytics ecosystem. 
 Here we are looking at how DuckDB revolutionized tabular data science and
 want to repeat it in graph data science! 
 
 ---
 
-This week, I presented Kùzu to the database community at the [CIDR 2023](https://www.cidrdb.org/cidr2023/papers/p48-jin.pdf) 
+This week, I presented Kuzu to the database community at the [CIDR 2023](https://www.cidrdb.org/cidr2023/papers/p48-jin.pdf) 
 conference in Amsterdam. For those who are not familiar with academic database conferences, 
 CIDR brings together work from academia and industry to discuss recent research on 
-systems aspects of database technology. Our paper was about Kùzu's 
+systems aspects of database technology. Our paper was about Kuzu's 
 goals and vision and its core query processor design for evaluating complex growing joins.
 We intentionally targeted CIDR for our paper because of its systems 
 focus and we thought many system gurus would be there: the attendees included 
@@ -74,22 +74,22 @@ enterprise applications.
 
 I want to start a 3-part blog post to cover the contents of our CIDR paper in a less academic language: 
 
-- __Post 1__: Kùzu's goals and vision as a system (this post)
+- __Post 1__: Kuzu's goals and vision as a system (this post)
 - __Post 2__: [Factorization technique for compression](../factorization)
 - __Post 3__: [Worst-case optimal join algorithms](../wcoj)
 
 In this Post 1, I discuss the following: 
    (i)   [an overview of GDBMSs](#overview-of-gdbms-and-a-bit-of-history).
    (ii)  [the features GDBMSs should optimize  for and why;](#features-every-competent-gdbms-should-optimize-for-) and 
-   (iii) [an example application domain (graph data science!) we are immediately targeting with Kùzu. ](#kùzu-as-a-gdbms-for-graph-data-science-pipelines)
+   (iii) [an example application domain (graph data science!) we are immediately targeting with Kuzu. ](#kùzu-as-a-gdbms-for-graph-data-science-pipelines)
 (ii) and (iii) should give you a good idea about the current goals and 
-vision of Kùzu. If you know GDBMSs well, you should skip over (i).
+vision of Kuzu. If you know GDBMSs well, you should skip over (i).
 
 ## Overview of GDBMSs and a Bit of History 
 In one sentence, GDBMSs are read-optimized analytical DBMSs for modeling and querying application 
 data as a graph. As a consequence they are optimized for fast querying of node and 
 relationship records. 
-Modern GDBMSs, such as Neo4j, Tigergraph, MemGraph, or Kùzu, 
+Modern GDBMSs, such as Neo4j, Tigergraph, MemGraph, or Kuzu, 
 adopt the [property graph data model](https://neo4j.com/developer/graph-database/#property-graph)
 (or its variants), where you can model your records as a set of labeled nodes and 
 edges/relationships, and key-value properties on these relationships. When
@@ -170,7 +170,7 @@ DBMSs are very complex software systems and they make a ton of design tradeoffs 
 what they optimize for. There is a very distinctive set of technical features that 
 GDBMSs should optimize for and excel in, where RDBMSs and SQL traditionally don't.
 This feature set is exactly what 
-Kùzu aims to perfect over time, which is what I hope to articulate in this post.
+Kuzu aims to perfect over time, which is what I hope to articulate in this post.
 In short: GDBMSs do offer a ton of value if 
 they are architected correctly and every software engineer should know 
 about GDBMSs[^3].
@@ -219,7 +219,7 @@ you are asking a system to search through `k^t` many possible combinations and g
 functions are scary. We have been advocating the integration of 2 specific techniques
 into the query processors of GDBMSs for several years now: (i) factorization; and (ii) worst-case optimal joins.
 Both of these techniques are specifically designed for 
-many-to-many growing joins and we have integrated them in Kùzu. Stay tuned for for my next two posts on this. 
+many-to-many growing joins and we have integrated them in Kuzu. Stay tuned for for my next two posts on this. 
 
 ### Feature 3: Recursive Join Queries
 This is probably the most obvious feature where GDBMSs should excel in. First, objectively 
@@ -242,7 +242,7 @@ In contrast, recursion has been first-class citizen
 feature in every graph-based DBMS's query language.
 This distinction is even much more visible
 if you want to do other graph-specific recursive computation, such as finding shortest paths.
-In  Kùzu, we are starting to work on implementing 
+In  Kuzu, we are starting to work on implementing 
 and optimizing recursive query support and we hope to have first a basic version and 
 then optimized versions that hopefully works very well and contributes to the principles of how these
 queries should be evaluated.
@@ -315,13 +315,13 @@ many other applications require and benefit
 from the above feature set.  One can
 think of the dataset and workloads of these applications as the "beyond relational/SQL" datasets/workloads, which
 often require modeling and querying in a graph-based DBMS, and
-we want Kùzu to excel in and represent the state-of-art in this feature set! 
+we want Kuzu to excel in and represent the state-of-art in this feature set! 
 
-## Kùzu as a GDBMS for Graph Data Science Pipelines
+## Kuzu as a GDBMS for Graph Data Science Pipelines
 
 Finally, let me tell you a little bit about 
 a particular application domain we are currently excited
-about and we want to see Kùzu used in: graph data science in the python ecosystem!
+about and we want to see Kuzu used in: graph data science in the python ecosystem!
 This figure from my CIDR slides describes this vision pictorially:
 
 <Image src="/img/2023-01-12-what-every-gdbms-should-do/kuzu-as-gdbms-of-gds.png" width="600" /> 
@@ -335,7 +335,7 @@ You might even want a pipeline
 that extracts regular tables from your graphs to a tabular data science library, 
 such as NumPy,
 since the outputs of queries in Cypher are tables of records.
-We want people to use Kùzu as an embeddable library in their Python scripts, 
+We want people to use Kuzu as an embeddable library in their Python scripts, 
 to do their modeling, querying, feature extraction, 
 cleaning, and other transformations, all by benefiting from a high-level query language 
 and state-of-art graph data management techniques
@@ -346,7 +346,7 @@ and suggestions for features we should implement to enable your workloads.
 
 OK, this is it for now. In the next two blog posts, I will discuss 
 factorization and worst-case optimal join algorithms and describe 
-some of the principles that we adopted in Kùzu's query processor.
+some of the principles that we adopted in Kuzu's query processor.
 Until then, happy new year from the cold but cozy winter of 🇨🇦 
 and [pip install kuzu](https://github.com/kuzudb/kuzu)!
 
@@ -358,10 +358,10 @@ and [pip install kuzu](https://github.com/kuzudb/kuzu)!
 
 [^3]: I am a strong supporter of devoting a few lectures to GDBMSs after covering the fundamental topics on the relational model and RDBMSs in core introduction to DBMSs courses in undergraduate curriculums. Students should broaden their perspectives on the available data models and query/programming languages to them when they develop applications. GDBMSs is an obvious choice here. So is Datalog and RDF/SparQL.
 
-[^4]: We articulated this list of features in our CIDR 2023 paper. Incidentally, [a paper](https://www.cidrdb.org/cidr2023/papers/p66-wolde.pdf) written by CWI on a graph query extension to DuckDB, had a 12-item list of "techniques" that GDBMSs should implement at their cores. Let me call this the CWI list. These items are not features in the sense I'm using the word, so I call them techniques. As you'll see my features are higher-level system properties from user's perspective. Peter Boncz, who is renowned in the field for having written or advised many successful DBMSs that spinned off, presented the CWI paper. I highly recommend this as another reading if you want to know more about Peter and his co-authors' technical insights about how GDBMSs should be architected. Importantly, Kùzu has integrated or is in the process of integrating 11 of the 12 techniques in the CWI list(bulk path finding is the one we have to do more thinking on) and our prior publications had also articulated many of these insights,  such as the fact that [GDBMSs should be columnar systems](https://www.vldb.org/pvldb/vol14/p2491-gupta.pdf) doing vectorized querying and of course we did a ton of work on [worst-case optimal joins](https://www.vldb.org/pvldb/vol12/p1692-mhedhbi.pdf) and [factorization](https://www.cidrdb.org/cidr2023/papers/p48-jin.pdf), which are also in the CWI list. I should acknowledge that Peter had been advocating for some of the techniques on the CWI list at least since 2018. I remember a presentation he gave in 2018 to GDBMSs researchers and developers titled "Why are Existing GDBMSs Incompetent?", which listed some of the techniques in the CWI list and visibly has inspired the title of this blog.
+[^4]: We articulated this list of features in our CIDR 2023 paper. Incidentally, [a paper](https://www.cidrdb.org/cidr2023/papers/p66-wolde.pdf) written by CWI on a graph query extension to DuckDB, had a 12-item list of "techniques" that GDBMSs should implement at their cores. Let me call this the CWI list. These items are not features in the sense I'm using the word, so I call them techniques. As you'll see my features are higher-level system properties from user's perspective. Peter Boncz, who is renowned in the field for having written or advised many successful DBMSs that spinned off, presented the CWI paper. I highly recommend this as another reading if you want to know more about Peter and his co-authors' technical insights about how GDBMSs should be architected. Importantly, Kuzu has integrated or is in the process of integrating 11 of the 12 techniques in the CWI list(bulk path finding is the one we have to do more thinking on) and our prior publications had also articulated many of these insights,  such as the fact that [GDBMSs should be columnar systems](https://www.vldb.org/pvldb/vol14/p2491-gupta.pdf) doing vectorized querying and of course we did a ton of work on [worst-case optimal joins](https://www.vldb.org/pvldb/vol12/p1692-mhedhbi.pdf) and [factorization](https://www.cidrdb.org/cidr2023/papers/p48-jin.pdf), which are also in the CWI list. I should acknowledge that Peter had been advocating for some of the techniques on the CWI list at least since 2018. I remember a presentation he gave in 2018 to GDBMSs researchers and developers titled "Why are Existing GDBMSs Incompetent?", which listed some of the techniques in the CWI list and visibly has inspired the title of this blog.
 
 [^5]: Although some refer to these as an "adjacency list index" because that's a common term in graph terminology, I need to pay my respects to the giants in the field: these are plain old [1980s Valduriez join indices](https://dl.acm.org/doi/abs/10.1145/22952.22955). And no, they were invented in the context of RDBMSs. That said, they never found much adoption in RDBMSs. But they are almost universally adopted in GDBMSs.
 
 [^6]: Designing the schema, i.e., defining the types of entities and relationships and class structures and constraints of such complex domains can be decades of work. What I'm referring to as schema is called an "ontology" in knowledge graph/semantic web space. If you ever thought you modeled a hard application domain, take a look at [SNOMED](https://en.wikipedia.org/wiki/SNOMED_CT), which is a decades long effort to model and standardize human medical knowledge. Last term, I had a seminar on SNODEM in my graduate course on knowledge graphs and students were baffled by the complexity of this "ontology", which  describes the types of entities and their relationships and constraints, which RDF technology stack is quite good at.
 
-[^7]: Before we released Kùzu, we had support for adding arbitrary node/edge properties but we removed a large chunk of code out of the system to release a thinner code base. So currently you need to specify a schema for your nodes and relationships in Kùzu. We will wait and see if/when that demand comes and how strongly it comes. We know from our conversations with many users and developers of GDBMSs over the years that most datasets in enterprises are not this complex and can be structured. At least after a proof of concept phase of applications, developers structure their data.
+[^7]: Before we released Kuzu, we had support for adding arbitrary node/edge properties but we removed a large chunk of code out of the system to release a thinner code base. So currently you need to specify a schema for your nodes and relationships in Kuzu. We will wait and see if/when that demand comes and how strongly it comes. We know from our conversations with many users and developers of GDBMSs over the years that most datasets in enterprises are not this complex and can be structured. At least after a proof of concept phase of applications, developers structure their data.

--- a/src/content/post/2023-02-13-kuzu-v-0.0.2.md
+++ b/src/content/post/2023-02-13-kuzu-v-0.0.2.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.0.2-release"
-title: "Kùzu 0.0.2 Release"
-description: "Release announcement for Kùzu 0.0.2"
+title: "Kuzu 0.0.2 Release"
+description: "Release announcement for Kuzu 0.0.2"
 pubDate: "Feb 13 2023"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -9,7 +9,7 @@ authors: ["team"]
 tags: ["pytorch-geometric", "networkx", "cypher"]
 ---
 
-This post is about the second release of Kùzu. However, we want to start with something much more important:
+This post is about the second release of Kuzu. However, we want to start with something much more important:
 
 ### Donate to the Victims of [Türkiye-Syria Earthquake](https://www.bbc.com/news/world-middle-east-64590946):
 Our hearts, thoughts, and prayers go to all the victims, those who survived and those who passed,
@@ -21,9 +21,9 @@ victims on the ground. For Türkiye (where Semih is from), you can donate to [Ah
 you can donate to the [White Helmets](https://www.whitehelmets.org/en/). Please be generous! We'll leave pointers to several 
 other organizations below in this footnote[^1].
 
-## Overview of Kùzu 0.0.2
-Back to our release. Kùzu codebase is changing fast but this release still has a focus: we 
-have worked quite hard since the last release to integrate Kùzu to import data from
+## Overview of Kuzu 0.0.2
+Back to our release. Kuzu codebase is changing fast but this release still has a focus: we 
+have worked quite hard since the last release to integrate Kuzu to import data from
 different formats and export data to different formats. There are also several important 
 features in the new Cypher clauses and queries we support,  additional string 
 processing capabilities, and new DDL statement support. We will give a summary of each 
@@ -33,7 +33,7 @@ For installing the new version, please visit the [installation guide](https://ku
 the full
 [release notes are here](https://github.com/kuzudb/kuzu/releases). If you are eager to play with
 a few Colab notebooks, here are several links: 
-- [General Kùzu Demo](https://colab.research.google.com/drive/15OLPggnRSBmR_K9yzq6iAGE5MDzNwqoN)
+- [General Kuzu Demo](https://colab.research.google.com/drive/15OLPggnRSBmR_K9yzq6iAGE5MDzNwqoN)
 - [Export Query Results to Pytorch Geometric: Node Property Prediction Example](https://colab.research.google.com/drive/1fzcwBwTY-M19p7OOTIaynfgHFcAQo9NK)
 - [Export Query Results to Pytorch Geometric: Link Prediction Example](https://colab.research.google.com/drive/1QdX7CDdajIAb04lqaO5PfJlpKG-ljG28)
 - [Export Query Results to NetworkX](https://colab.research.google.com/drive/1NDsnFDWcSGoaOl-mOgG0zrPG2VAr8Q6H)
@@ -59,19 +59,19 @@ want to manually put them into the `Data/HeteroData` objects.
 
 **Colab Demonstrations:**
 Here are 2 Colab notebooks that you can play around with to see how you can develop graph learning
-pipelines using Kùzu as your GDBMSs:
+pipelines using Kuzu as your GDBMSs:
 1. [Node property prediction](https://colab.research.google.com/drive/1fzcwBwTY-M19p7OOTIaynfgHFcAQo9NK)
 2. [Link prediction](https://colab.research.google.com/drive/1QdX7CDdajIAb04lqaO5PfJlpKG-ljG28)
 
 The examples demonstrate how to extract a subgraph,
 train graph convolutional or neural networks (GCNs or GNNs), make some node property
-or link predictions and save them back in Kùzu so you can query these predictions.
+or link predictions and save them back in Kuzu so you can query these predictions.
 
 ### NetworkX: `QueryResult.get_as_networkx()` function
 Our [Python API](https://kuzudb.com/docs/client-apis/python-api/overview.html) now has a 
 new [`QueryResult.get_as_networkx()`](https://kuzudb.com/api-docs/python/kuzu/query_result.html#QueryResult.get_as_networkx) function that can convert query results
 that contain nodes and relationships into NetworkX directed or undirected graphs. Using this function, you can build pipelines
-that benefits from Kùzu's DBMS functionalities (e.g., querying, data extraction and transformations,
+that benefits from Kuzu's DBMS functionalities (e.g., querying, data extraction and transformations,
 using a high-level query language with very fast performance), and NetworkX's rich library of 
 graph analytics algorithms.
 
@@ -79,7 +79,7 @@ graph analytics algorithms.
 Here is a [Colab notebook](https://colab.research.google.com/drive/1NDsnFDWcSGoaOl-mOgG0zrPG2VAr8Q6H?usp=sharing#scrollTo=AkpBul7ZpUM5) 
 that you can play around with that shows how to do basic graph visualization of query results
 and build a pipeline that computes PageRanks of a subgraph and store those PageRank 
-values back as new node properties in Kùzu and query them.
+values back as new node properties in Kuzu and query them.
 
 ## Data Import from and Export to Parquet and Arrow
 We have removed our own CSV reader and instead now use [Arrow](https://arrow.apache.org/)
@@ -126,7 +126,7 @@ This forces e to match to only Likes relationship or Follows relationship record
 excludes the `LivesIn` records we mentioned above). The `|` is a syntax adapted from
 regexes originally and is also used in query languages that support `regular path queries`. 
 
-Kùzu now supports such queries. Our query execution
+Kuzu now supports such queries. Our query execution
 is based on performing scans of each possible node/rel table and index
 and when a variable `x` can bind to multiple node/rel tables, `L1, L2, ..., Lk`,
 we reserve one vector for each possible property of each node/rel table.  
@@ -136,11 +136,11 @@ to hear!
 ## Other Important Changes
 
 ### Enhanced String Features
-We've added two important features to enhance Kùzu's ability to store and process strings:
+We've added two important features to enhance Kuzu's ability to store and process strings:
 
 1) Support of UTF-8 characters. With the help of [utf8proc](https://github.com/JuliaStrings/utf8proc), you can now store string node/relationship
-   properties in Kùzu that has UTF-8 characters;
-2) Support of [regex pattern matching](//docs.kuzudb.com/cypher/expressions/pattern-matching) with strings. Kùzu now supports Cypher's `=~` operator for regex searches, which will return true if its pattern mathces the entire input string. For example: `RETURN 'abc' =~ '.*(b|d).*';`.
+   properties in Kuzu that has UTF-8 characters;
+2) Support of [regex pattern matching](//docs.kuzudb.com/cypher/expressions/pattern-matching) with strings. Kuzu now supports Cypher's `=~` operator for regex searches, which will return true if its pattern mathces the entire input string. For example: `RETURN 'abc' =~ '.*(b|d).*';`.
 
 ### CASE Expression
 We've added [CASE](//docs.kuzudb.com/cypher/expressions/case-expression) for conditional expressions.

--- a/src/content/post/2023-02-22-wcoj.md
+++ b/src/content/post/2023-02-22-wcoj.md
@@ -39,7 +39,7 @@ recommendation applications. As such, they should be integrated into every graph
     paradigm can generate unnecessarily large amounts of intermediate results.
 - **Core Algorithmic Step of Wcoj Algorithms:**  Wcoj algorithms fix this sub-optimality by 
 performing the joins one column at a time (instead of 2 tables at a time) using multiway intersections.
-- **How Kùzu Integrates Wcoj Algorithms:** Kùzu generates plans that seamlessly mix binary joins 
+- **How Kuzu Integrates Wcoj Algorithms:** Kuzu generates plans that seamlessly mix binary joins 
 and WCOJ-style multiway intersections. Multiway intersections are performed by an operator called 
 "multiway HashJoin", which has one or more build phases that creates one or more hash tables that stores
 sorted adjacency lists; and a probe phase that performs multi-way intersections using the sorted lists.
@@ -256,10 +256,10 @@ forward index of a's, backward index of b's, and forward index of c's, to comple
 the triangles to joins. This type of multiway intersections is the necessary 
 algorithmic step to be efficient on cyclic queries.
 
-## How Kùzu Performs Worst-case Optimal Join Algorithms:
+## How Kuzu Performs Worst-case Optimal Join Algorithms:
 
 Our [CIDR paper](https://www.cidrdb.org/cidr2023/papers/p48-jin.pdf) describes this in detail, so I will be brief here. 
-First, Kùzu mixes binary joins and WCOJ-like multiway intersections
+First, Kuzu mixes binary joins and WCOJ-like multiway intersections
 following some principles that my PhD student [Amine Mhedhbi](http://amine.io/)
 had worked quite hard on early in his PhD. I recommend these two papers, 
 one by [Amine and me](https://www.vldb.org/pvldb/vol12/p1692-mhedhbi.pdf)
@@ -272,7 +272,7 @@ So WCOJ-like computations should be seen as complementing binary join plans.
 
 ![](/img/2023-02-22-wcoj/wcoj-kuzu-multiway-hash-join.png)
 
-Second, Kùzu performs multiway intersections in a *Multiway HashJoin* operator.
+Second, Kuzu performs multiway intersections in a *Multiway HashJoin* operator.
 In our CIDR paper we call this operator Multiway ASPJoin. It can be thought 
 of a modified hash-join operator where we use multiple hash tables and do 
 an intersection to produce outputs as I will simulate. 
@@ -315,7 +315,7 @@ This performs quite well. Our [CIDR paper](https://www.cidrdb.org/cidr2023/paper
 comparing against other types of WCO joins implementations (see the experiments in Table 3). Since I did not cover other ways to implement
 wco join algorithms inside DBMSs, these experiments would be difficult to explain here.
 Instead, let me just demonstrate some simple comparisons between using binary joins and wco joins
-in Kùzu on a simple triangle query. On larger cyclic queries, e.g., 4- or 5- cliques, 
+in Kuzu on a simple triangle query. On larger cyclic queries, e.g., 4- or 5- cliques, 
 the differences are much larger and often binary join plans do not finish on time.
 You can try this experiment too. 
 
@@ -324,20 +324,20 @@ is a popular web graph that is used in academic papers called [web-BerkStan](htt
 It has 685K nodes and 7.6M edges.
 I modeled these as a simple `Page` nodes and `Links` edges.
 
-I start Kùzu on my own laptop, which is a Macbook Air 2020 with Apple M1 chip, 16G memory,
-and 512GB SSD, and run the following two queries (by default, Kùzu uses all available threads, which is 8 in this case):
+I start Kuzu on my own laptop, which is a Macbook Air 2020 with Apple M1 chip, 16G memory,
+and 512GB SSD, and run the following two queries (by default, Kuzu uses all available threads, which is 8 in this case):
 
 ```cypher
-// Q1: Kùzu-WCO
+// Q1: Kuzu-WCO
 MATCH (a:Page)-[e1:Links]->(b:Page)-[e2:Links]->(c:Page)-[e3:Links]->(a)
 RETURN count(*)
 ```
 
 This will compile plan that uses a wco Multiway HashJoin operator. I will refer to this
-plan as Kùzu-WCO below. I am also running the following query:
+plan as Kuzu-WCO below. I am also running the following query:
 
 ```cypher
-// Q2: Kùzu-BJ
+// Q2: Kuzu-BJ
 MATCH (a:Page)-[e1:Links]->(b:Page)
 WITH *
 MATCH (b:Page)-[e2:Links]->(c:Page)
@@ -346,21 +346,21 @@ MATCH (c)-[e3:Links]->(a)
 RETURN count(*)
 ```
 
-Currently Kùzu compiles each `MATCH`/`WITH` block separately so this is hack to force the system
+Currently Kuzu compiles each `MATCH`/`WITH` block separately so this is hack to force the system
 to use binary join plan. The plan will join `e1` `Links` with `e2` `Links` and then
 join the result of that with `e3` `Links`, all using binary HashJoin operator. I will
-refer to this as Kùzu-BJ. Here are the results:
+refer to this as Kuzu-BJ. Here are the results:
 
 | Configuration |  Time  |
 |----------|:-------------:|
-| Kùzu-WCO | **1.62s** |
-| Kùzu-BJ |  51.17s   |
+| Kuzu-WCO | **1.62s** |
+| Kuzu-BJ |  51.17s   |
 
 There are ~41 million triangles in the output. We see **31.6x** performance improvement in this simple query. 
 In larger densely cyclic queries, binary join plans just don't work.
 
 To try this locally, you can download our prepared CSV files from [here](https://github.com/kuzudb/kuzudb.github.io/tree/main/data/web-berkstan), and compile from our [latest master](https://github.com/kuzudb/kuzu)[^2] -- use the command `make clean && make release NUM_THREADS=8`.
-Then start a Kùzu shell, and load data into Kùzu:
+Then start a Kuzu shell, and load data into Kuzu:
 
 ```bash
 ./build/release/tools/shell/kuzu -i web.db
@@ -369,7 +369,7 @@ kuzu> CREATE REL TABLE Links (FROM Page TO Page, MANY_MANY);
 kuzu> COPY Page FROM 'web-node.csv';
 kuzu> COPY Links FROM 'web-edge.csv';
 ```
-Now, run those two queries (Kùzu-WCO and Kùzu-BJ) to see the difference!
+Now, run those two queries (Kuzu-WCO and Kuzu-BJ) to see the difference!
 
 ## A thank you & an anecdote about Knuth's reaction to the term "Worst-case Optimal"
  
@@ -425,7 +425,7 @@ practical versions of these algorithms can be developed. That would be very exci
 
 This completes my 3-part blog on the contents of our CIDR paper and 2 core techniques:
 [factorization](../factorization) and worst-case optimal join algorithms that we have integrated into
-Kùzu to optimize for many-to-many joins. My goal in these blog
+Kuzu to optimize for many-to-many joins. My goal in these blog
 posts was to explain these ideas to a general CS/software engineering audience and
 I hope these posts have made this material more approachable. My other goal
 was to show the role of theory in advancing systems. Both of these ideas emerged from
@@ -436,7 +436,7 @@ because queries with many-to-many joins are first-class-citizens in the workload
 
 We will keep writing more blog posts in the later months about our new releases,
 and other technical topics. If there are things you'd like us to write about,
-please reach out to us on [Discord](https://discord.gg/VtX2gw9Rug)! Also please give Kùzu a try, prototype applications with it,
+please reach out to us on [Discord](https://discord.gg/VtX2gw9Rug)! Also please give Kuzu a try, prototype applications with it,
 break it, let us know of your performance or other bugs, so we can continue improving
 it. Also give us a [star](https://github.com/kuzudb/kuzu) on GitHub, and take care, until the next post!
 

--- a/src/content/post/2023-04-06-kuzu-v-0.0.3.md
+++ b/src/content/post/2023-04-06-kuzu-v-0.0.3.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.0.3-release"
-title: "Kùzu 0.0.3 Release"
-description: "Release announcement for Kùzu 0.0.3"
+title: "Kuzu 0.0.3 Release"
+description: "Release announcement for Kuzu 0.0.3"
 pubDate: "April 06 2023"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -9,7 +9,7 @@ authors: ["team"]
 tags: ["pytorch-geometric", "gnn", "data-type", "buffer-manager", "query-optimizer", "performance"]
 ---
 
-We are happy to release Kùzu 0.0.3 today. This release comes with the following new main features and improvements:
+We are happy to release Kuzu 0.0.3 today. This release comes with the following new main features and improvements:
 
 For installing the new version, 
 please visit the [download section of our website](https://kuzudb.com/#download) 
@@ -21,21 +21,21 @@ documentation website to play with our [Colab notebooks](https://kuzudb.com/docs
 Enjoy! Please give us a try, [a Github ⭐](https://github.com/kuzudb/kuzu) and your feedback and feature requests! Also follow
 us on [Twitter](https://twitter.com/kuzudb)!
 
-## Kùzu as a PyG Remote Backend
+## Kuzu as a PyG Remote Backend
 
-Kùzu now implements PyG's Remote Backend interface. So you can directly 
-train GNNs using Kùzu as your backend storage. Quoting the PyG [documentation's](https://pytorch-geometric.readthedocs.io/en/latest/advanced/remote.html) description
+Kuzu now implements PyG's Remote Backend interface. So you can directly 
+train GNNs using Kuzu as your backend storage. Quoting the PyG [documentation's](https://pytorch-geometric.readthedocs.io/en/latest/advanced/remote.html) description
 of the Remote Backend feature:
 
 > ...[this feature enables] users to train GNNs on graphs far larger than the size of their
 machine’s available memory. It does so by introducing simple, easy-to-use, and extensible abstractions of a `torch_geometric.data.FeatureStore` and a   `torch_geometric.data.GraphStore` that plug directly into existing familiar PyG interfaces.
 
-With our current release, once you store your graph and features in Kùzu,
-PyG's samplers work seamlessly using Kùzu's implementation of `FeatureStore` and `GraphStore` interfaces. For example, 
+With our current release, once you store your graph and features in Kuzu,
+PyG's samplers work seamlessly using Kuzu's implementation of `FeatureStore` and `GraphStore` interfaces. For example, 
 this enables your existing GNN models to work seamlessly by fetching both subgraph samples and node features
-from Kùzu instead of PyG's in-memory storage. 
+from Kuzu instead of PyG's in-memory storage. 
 Therefore you can train graphs that do not
-fit into your memory since Kùzu, as a DBMS, stores its data on disk. Try this demonstrative [Colab notebook](https://colab.research.google.com/drive/12fOSqPm1HQTz_m9caRW7E_92vaeD9xq6) to 
+fit into your memory since Kuzu, as a DBMS, stores its data on disk. Try this demonstrative [Colab notebook](https://colab.research.google.com/drive/12fOSqPm1HQTz_m9caRW7E_92vaeD9xq6) to 
 see an example of how to do this. The current release comes with a limitation that we only truly implement the `FeatureStore` interface.
 Inside `GraphStore` we still store the graph topology in memory. 
 So in reality only the features are stored and scanned from disk. We plan to address this limitation later on.
@@ -50,27 +50,27 @@ We used a machine with one RTX 4090 GPU with 24 GB of memory, two Xeon Platinum 
 is enough for PyG's in-memory store to store the entire graph and all features in memory.
 
 During training, we use the `NeighborLoader` of PyG with batch size of 48000 and sets the `num_neighbors` to `[30] * 2`, which means at each batch roughly 60 neighbor nodes of 48000 nodes will be sampled from the `GraphStore` and the features of those nodes will be scanned
-from Kùzu's storage. We picked this sample size because this gives us a peak GPU memory usage of approximately 22 GB, i.e.,
+from Kuzu's storage. We picked this sample size because this gives us a peak GPU memory usage of approximately 22 GB, i.e.,
 we can saturate the GPU memory. We used 16 cores[^2] during the sampling process. We run each experiment in a Docker instance
 and limit the memory systematically from 110GB, which is enough for PyG to run completely in memory, down to 90, 70, and 60GB.
-At each memory level we run the same experiment by using Kùzu as a Remote Backend, where we 
-have to use about 48GB to store the topology and give the remaining memory to Kùzu's buffer manager.
-For example when the memory is 60GB, we can only give ~10GB to Kùzu.
+At each memory level we run the same experiment by using Kuzu as a Remote Backend, where we 
+have to use about 48GB to store the topology and give the remaining memory to Kuzu's buffer manager.
+For example when the memory is 60GB, we can only give ~10GB to Kuzu.
 
 | Configuration                 | End to End Time (s) | Per Batch Time (s)  | Time Spent on Training (s) | Time Spent on Copying to GPU (s) | Docker Memory |
 |-------------------------------|-----------------|-----------------|------------------------|------------------------------|-------------|
 |         PyG In-memory         |      140.17     |      1.4       |          6.62          |             31.25            | 110 GB      |
-| Kùzu Remote Backend (bm=60GB) |     392.6     |      3.93      |          6.29          |             34.18            | 110 GB       |
-| Kùzu Remote Backend (bm=40GB) |     589.0     |      5.89      |          6.8          |             32.6            | 90 GB       |
-| Kùzu Remote Backend (bm=20GB) |     1156.1     |      11.5      |          6.0          |             36            | 70 GB       |
-| Kùzu Remote Backend (bm=10GB) |     1121.92     |      11.21      |          6.88          |             35.03            | 60 GB   |
+| Kuzu Remote Backend (bm=60GB) |     392.6     |      3.93      |          6.29          |             34.18            | 110 GB       |
+| Kuzu Remote Backend (bm=40GB) |     589.0     |      5.89      |          6.8          |             32.6            | 90 GB       |
+| Kuzu Remote Backend (bm=20GB) |     1156.1     |      11.5      |          6.0          |             36            | 70 GB       |
+| Kuzu Remote Backend (bm=10GB) |     1121.92     |      11.21      |          6.88          |             35.03            | 60 GB   |
 
 So, when have enough memory, there is about 2.8x slow down (from 1.4s to 3.93s per batch). This
-is the case when Kùzu has enough buffer memory (60GB) to store the 53GB of features but we still incur the cost of 
-scanning them through Kùzu's buffer manager. So no or very little disk I/O happens (except the first time
-the features are scanned to the buffer manager). Then as we lower the memory, Kùzu can hold only part 
+is the case when Kuzu has enough buffer memory (60GB) to store the 53GB of features but we still incur the cost of 
+scanning them through Kuzu's buffer manager. So no or very little disk I/O happens (except the first time
+the features are scanned to the buffer manager). Then as we lower the memory, Kuzu can hold only part 
 of the of node features in its buffer manager, so
-we force Kùzu to do more and more I/O. The per batch time increase to 5.89s at 40GB of buffer manager size, 
+we force Kuzu to do more and more I/O. The per batch time increase to 5.89s at 40GB of buffer manager size, 
 then seems to stabilize around 11s (so around 8.2x slowdown). 
 
 The slow down is better if you use smaller batch sizes but for the end to end training time, you
@@ -156,7 +156,7 @@ which we verified improves our query performance a lot.
 We now support several additional data types that were missing.
 
 **[FIXED-LIST](//docs.kuzudb.com/cypher/data-types/list/) data type:** This is important if you're doing graph ML and storing node features
-in Kùzu. It is the efficient way to store fixed-length vectors. Here's the summary of how
+in Kuzu. It is the efficient way to store fixed-length vectors. Here's the summary of how
 to declare a node or rel property in your schemas to use the fixed-list data type.
 
 | Data Type | Description | DDL definition |
@@ -198,4 +198,4 @@ Note: The Interruption and Query Timeout features are not applicable to `COPY` c
 ---
 
 [^1]: Internally, PyG coverts the edge list to CSC format for sampling, which duplicates the graph structures in memory. When you download the graph topology it actually takes about 24GB.
-[^2]: We set `num_workers` to 16 when running the PyG in-memory setup. Since Kùzu does not currently work with multiple workers in Python, we limit `num_workers` to 1 when sampling from Kùzu but internally Kùzu scans in parallel with 16 threads.
+[^2]: We set `num_workers` to 16 when running the PyG in-memory setup. Since Kuzu does not currently work with multiple workers in Python, we limit `num_workers` to 1 when sampling from Kuzu but internally Kuzu scans in parallel with 16 threads.

--- a/src/content/post/2023-06-05-kuzu-v-0.0.4.md
+++ b/src/content/post/2023-06-05-kuzu-v-0.0.4.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.0.4-release"
-title: "Kùzu 0.0.4 Release"
-description: "Release announcement for Kùzu 0.0.4"
+title: "Kuzu 0.0.4 Release"
+description: "Release announcement for Kuzu 0.0.4"
 pubDate: "June 05 2023"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -9,7 +9,7 @@ authors: ["team"]
 tags: ["data-type", "cypher", "performance"]
 ---
 
-We are very happy to release Kùzu 0.0.4 today! This release comes with the following new main features and improvements:
+We are very happy to release Kuzu 0.0.4 today! This release comes with the following new main features and improvements:
 
 ## Data Ingestion Improvements
 We continue to improve our data ingestion in this release. 
@@ -40,14 +40,14 @@ We will continue to improve our data ingestion to make it more efficient and rob
 ## New Cypher Features
 
 ### Undirected Relationships in Queries
-Kùzu now supports undirected relationships in Cypher queries. An undirected relationship is the union of both in-coming and out-going relationships. This feature is mostly useful in the following two cases. 
+Kuzu now supports undirected relationships in Cypher queries. An undirected relationship is the union of both in-coming and out-going relationships. This feature is mostly useful in the following two cases. 
 
 **Case 1: Relationship is undirected by nature**
-Relationships between nodes in Kùzu are currently directed (though we are internally debating to add a native undirected relationship type). A relationship file must contain `FROM` and `TO` columns each of which refers to a primary key column of a node table. However, sometimes the nature of the relationships are undirected, e.g., an `isFriendOf` relationships in a social network. 
+Relationships between nodes in Kuzu are currently directed (though we are internally debating to add a native undirected relationship type). A relationship file must contain `FROM` and `TO` columns each of which refers to a primary key column of a node table. However, sometimes the nature of the relationships are undirected, e.g., an `isFriendOf` relationships in a social network. 
 
-Currently, you have two options: (1) you can either store each friendship twice, e.g., `Alice isFriendOf Bob` and `Bob isFriendOf Alice`. This is a bad choice because internally Kùzu will index each edge twice (in the forward and backward) edges, so this one fact ends up getting stored 4 times. Or (2) you can store it once, say `Alice isFriendOf Bob`. 
+Currently, you have two options: (1) you can either store each friendship twice, e.g., `Alice isFriendOf Bob` and `Bob isFriendOf Alice`. This is a bad choice because internally Kuzu will index each edge twice (in the forward and backward) edges, so this one fact ends up getting stored 4 times. Or (2) you can store it once, say `Alice isFriendOf Bob`. 
 
-The advantage of option (1) was that in Kùzu v 0.0.3, if you want to find all friends of `Alice`, you could simply ask this query:
+The advantage of option (1) was that in Kuzu v 0.0.3, if you want to find all friends of `Alice`, you could simply ask this query:
 
 ```cypher
 MATCH (a:Person)-[:isFriendOf]->(b:Person)
@@ -64,16 +64,16 @@ WHERE a.name = 'Alice'
 RETURN b;
 ```
 
-So if you do not specify a direction in your relationships, Kùzu will automatically query both the forward and backward relationships for you.
+So if you do not specify a direction in your relationships, Kuzu will automatically query both the forward and backward relationships for you.
 
-*Note from Kùzu developers: As noted above, we are debating a native undirected relationship type. That seems to solve the problem of, in which fake direction should an undirected relationship be saved at? Should be a `Alice-[isFriendOf]->Bob` or vice versa. Happy to hear your thoughts on this.*
+*Note from Kuzu developers: As noted above, we are debating a native undirected relationship type. That seems to solve the problem of, in which fake direction should an undirected relationship be saved at? Should be a `Alice-[isFriendOf]->Bob` or vice versa. Happy to hear your thoughts on this.*
 
 **Case 2: Relationship direction is not of interest**
-Although relationship is stored in a directed way, its direction may not be of interest in the query. The following query tries to find all comments that have interacted with comment `Kùzu`. These comments could be either replying to or replied by `Kùzu`. The query can be asked naturally in an undirected way.
+Although relationship is stored in a directed way, its direction may not be of interest in the query. The following query tries to find all comments that have interacted with comment `Kuzu`. These comments could be either replying to or replied by `Kuzu`. The query can be asked naturally in an undirected way.
 
 ```cypher
 MATCH (c:Comment)-[:replyOf]-(other:Comment)
-WHERE c.author = 'Kùzu'
+WHERE c.author = 'Kuzu'
 RETURN other;
 ```
 
@@ -93,7 +93,7 @@ RETURN b
 But you couldn't ask for arbitrary labeled variable-length relationships between Persons `a` and `b` (though you
 could write the non-recursive version of that query: `MATCH (a:Person)-[:knows]->(b:Person) ...`. 
 Similarly we did not support undirected version of the query: `MATCH (a:Person)-[:knows*1..2]-(b:Person)`.
-Kùzu now supports multi-label as well as undirected variable-length relationships.
+Kuzu now supports multi-label as well as undirected variable-length relationships.
 For example, the following query finds all nodes that are reachable within 1 to 3 hops from `Alice`, irrespective
 of the labels on the connections or destination `b` nodes:
 
@@ -152,7 +152,7 @@ Output:
 When the primary key of your node tables are already consecutive integers starting from 0, you should omit the primary key column in the input file and make primary key a SERIAL type. This will improve loading time significantly. Similarly, queries that need to scan primary key will also get faster. That's because internally we will not store a HashIndex or primary key column so any scan over primary key will not trigger a disk I/O.
 
 ### `STRUCT`
-Kùzu now supports `STRUCT` data type similar to [composite type](https://www.postgresql.org/docs/current/rowtypes.html) in Postgres. Here is an example:
+Kuzu now supports `STRUCT` data type similar to [composite type](https://www.postgresql.org/docs/current/rowtypes.html) in Postgres. Here is an example:
 
 ```cypher
 WITH {name:'University of Waterloo', province:'ON'} AS institution
@@ -176,11 +176,11 @@ nested structs, e.g., structs that contain structs as a field, on nodes. One mis
 ## Client APIs
 
 ### Windows compatibility
-Developers can now build Kùzu from scratch on Windows platform! Together with this release we also provide pre-built libraries and python wheels on Windows.
+Developers can now build Kuzu from scratch on Windows platform! Together with this release we also provide pre-built libraries and python wheels on Windows.
 
 ### C
-We provide official C language binding in this release. Developers can now embed Kùzu with native C interfaces.
+We provide official C language binding in this release. Developers can now embed Kuzu with native C interfaces.
 
 ### Node.js
-We provide official Node.js language binding. With Node.js API, developer can leverage Kùzu analytical capability in their Node.js projects. We will
+We provide official Node.js language binding. With Node.js API, developer can leverage Kuzu analytical capability in their Node.js projects. We will
 soon follow this blog post with one (or a few) blog posts on developing some applications with Node.js.

--- a/src/content/post/2023-07-10-kuzu-v-0.0.5.md
+++ b/src/content/post/2023-07-10-kuzu-v-0.0.5.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.0.5-release"
-title: "Kùzu 0.0.5 Release"
-description: "Release announcement for Kùzu 0.0.5"
+title: "Kuzu 0.0.5 Release"
+description: "Release announcement for Kuzu 0.0.5"
 pubDate: "July 10 2023"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -9,7 +9,7 @@ authors: ["team"]
 tags: ["data-type", "cypher", "performance"]
 ---
 
-We are very happy to release Kùzu 0.0.5 today! This release comes with the following new main features and improvements:
+We are very happy to release Kuzu 0.0.5 today! This release comes with the following new main features and improvements:
 
 ## Cypher Features
 
@@ -59,7 +59,7 @@ RETURN DISTINCT b.name;
 Our filter grammar follows [Memgraph's syntax](https://memgraph.com/docs/memgraph/reference-guide/built-in-graph-algorithms). The first variable `r` in the `(r, _ | WHERE r.since < 2022)` predicate binds to the relationships in the recursive pattern and the `_` binds to the nodes. Since we currently don't allow filters on recursive nodes, the second variable must be `_` for now.
 
 ### All Shortest Paths
-Kùzu now supports all shortest paths semantic with key word `ALL SHORTEST`. The following query finds all shortest paths of up to length 3 between `Zhang` and `Waterloo` considering relationships of all labels (i.e., this is an unlabeled query and you can restrict the labels by adding them as `[:Follows* ALL SHORTEST 1..3]`).
+Kuzu now supports all shortest paths semantic with key word `ALL SHORTEST`. The following query finds all shortest paths of up to length 3 between `Zhang` and `Waterloo` considering relationships of all labels (i.e., this is an unlabeled query and you can restrict the labels by adding them as `[:Follows* ALL SHORTEST 1..3]`).
 
 ```cypher
 MATCH p = (a)-[* ALL SHORTEST 1..3]-(b) 
@@ -124,13 +124,13 @@ RETURN BLOB('\\xBC\\xBD\\xBA\\xAA') as result;
 More information on the blob data type can be found [here](//docs.kuzudb.com/cypher/data-types/blob).
 
 ## Client APIs: Rust and Java
-In this release, we're expanding the accessibility of Kùzu, bridging the gap with some of the most popular programming languages in the developer community. Specifically, we now have [Rust](//docs.kuzudb.com/client-apis/rust) and [Java](//docs.kuzudb.com/client-apis/java) APIs.
+In this release, we're expanding the accessibility of Kuzu, bridging the gap with some of the most popular programming languages in the developer community. Specifically, we now have [Rust](//docs.kuzudb.com/client-apis/rust) and [Java](//docs.kuzudb.com/client-apis/java) APIs.
 
 ## Development: Testing Framework
 
 Starting with this release, we're adding some development guidelines to encourage and facilitate outside contributions from the broader open source community.
 
-Testing is a crucial part of Kùzu to ensure the correct functioning of the system.
+Testing is a crucial part of Kuzu to ensure the correct functioning of the system.
 In this release, we've implemented significant changes to our testing framework. Our approach to testing is rooted in the principle of end-to-end tests rather than individual unit tests.
 Whenever possible, we route all tests in the end-to-end way through Cypher statements. 
 To this end, we've designed a custom testing framework that enables thorough end-to-end testing via Cypher statements.

--- a/src/content/post/2023-07-17-kuzu-v-0.0.6.md
+++ b/src/content/post/2023-07-17-kuzu-v-0.0.6.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.0.6-release"
-title: "Kùzu 0.0.6 Release"
-description: "Release announcement for Kùzu 0.0.6"
+title: "Kuzu 0.0.6 Release"
+description: "Release announcement for Kuzu 0.0.6"
 pubDate: "July 17 2023"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -9,7 +9,7 @@ authors: ["team"]
 tags: ["data-type"]
 ---
 
-We are thrilled to announce the release of Kùzu 0.0.6, which focuses on addressing bugs reported by our users. We addressed the following issues in this bug-fix release:
+We are thrilled to announce the release of Kuzu 0.0.6, which focuses on addressing bugs reported by our users. We addressed the following issues in this bug-fix release:
 
 1. Resolved a segmentation fault occurring while loading overflow data types with parallelism.
 2. Fixed an issue of reading out of bound for LIST vector null buffer.
@@ -17,4 +17,4 @@ We are thrilled to announce the release of Kùzu 0.0.6, which focuses on address
 
 For more detailed information about the changes in this release, please visit [this link](https://github.com/kuzudb/kuzu/releases/tag/v0.0.6). 
 
-We extend our sincere gratitude to all our users who reported these bugs, as well as to everyone who supported us throughout this process. Your feedback is instrumental in making Kùzu better!
+We extend our sincere gratitude to all our users who reported these bugs, as well as to everyone who supported us throughout this process. Your feedback is instrumental in making Kuzu better!

--- a/src/content/post/2023-07-19-iamgraphviz.md
+++ b/src/content/post/2023-07-19-iamgraphviz.md
@@ -1,6 +1,6 @@
 ---
 slug: "iamgraphviz"
-title: "IAMGraphViz: Visualizing AWS IAM Permissions with Kùzu"
+title: "IAMGraphViz: Visualizing AWS IAM Permissions with Kuzu"
 description: "An example of using graph visualizations for infrastructure engineers to analyze the 
 IAM network of an enterprise"
 pubDate: "July 19 2023"
@@ -10,9 +10,9 @@ authors: ["chang", {"name": "Chris Norman", "image": "/img/authors/chris.jpeg", 
 tags: ["visualization"]
 ---
 
-[Common Fate](https://www.commonfate.io/)  is a framework for managing complex cloud permissions. They provide tools to simplify access at scale to AWS, Azure, and Google Cloud accounts. You can learn about what you can do with Common Fate on [their website](https://www.commonfate.io/). Here, we will talk about a recent proof of concept graph visualization tool called IAMGraphViz that [Chang Liu](https://www.linkedin.com/in/mewim/) (who is coauthoring this post) and I developed using Kùzu! IAMGraphViz is intended for infrastructure engineers to dig deep into the permission assignments in AWS IAM Identity Center using graph visualization. Using IAMGraphViz, one can easily visualize who has what type of access to different accounts on AWS as well as how they have access to these accounts. This is all done by analyzing the paths from users to accounts in a graph visualization, where the nodes and edges model users, accounts, groups, group memberships, permission sets and other entities in the AWS IAM Identity Center system.
+[Common Fate](https://www.commonfate.io/)  is a framework for managing complex cloud permissions. They provide tools to simplify access at scale to AWS, Azure, and Google Cloud accounts. You can learn about what you can do with Common Fate on [their website](https://www.commonfate.io/). Here, we will talk about a recent proof of concept graph visualization tool called IAMGraphViz that [Chang Liu](https://www.linkedin.com/in/mewim/) (who is coauthoring this post) and I developed using Kuzu! IAMGraphViz is intended for infrastructure engineers to dig deep into the permission assignments in AWS IAM Identity Center using graph visualization. Using IAMGraphViz, one can easily visualize who has what type of access to different accounts on AWS as well as how they have access to these accounts. This is all done by analyzing the paths from users to accounts in a graph visualization, where the nodes and edges model users, accounts, groups, group memberships, permission sets and other entities in the AWS IAM Identity Center system.
 
-The IAMGraphViz project is designed and implemented as a web application using a graph DBMS (GDBMS) to store and retrieve data. Before landing on Kùzu, we surveyed using several other GDBMSs, such as Neo4j, but they were all harder to use. Neo4j, for example, requires hosting a separate database. We then discovered Kùzu, which only required a `pip install` and import statement and we could simply embed it into our application. In this project our datasets could fit entirely onto a single compute node,and so Kùzu was far simpler for us to work with than alternatives. Kùzu is also far cheaper and more serverless-friendly than running a separate database.
+The IAMGraphViz project is designed and implemented as a web application using a graph DBMS (GDBMS) to store and retrieve data. Before landing on Kuzu, we surveyed using several other GDBMSs, such as Neo4j, but they were all harder to use. Neo4j, for example, requires hosting a separate database. We then discovered Kuzu, which only required a `pip install` and import statement and we could simply embed it into our application. In this project our datasets could fit entirely onto a single compute node,and so Kuzu was far simpler for us to work with than alternatives. Kuzu is also far cheaper and more serverless-friendly than running a separate database.
 
 This post follows the [Colab](https://colab.research.google.com/drive/1fotlNnOj1FGad6skBG7MRrHVdHd3jIl6) that Chang Liu created after we discussed this use case together.
 
@@ -22,7 +22,7 @@ So let's get to it!
 
 We will use the data model shown in the figure below that faithfully (but partially) models the
 core concepts of AWS IAM permission management. Let's first review these concepts, all
-of which will be modeled as nodes in Kùzu, as a background.
+of which will be modeled as nodes in Kuzu, as a background.
 We will provide as simple definitions as we can to keep the post short and provide links
 to necessary AWS IAM documentation: 
 
@@ -104,6 +104,6 @@ Many other graph visualizations can be helpful for infrastructure engineers to a
 IAM network of an enterprise. For example, to find inconsistent privileges given to users,
 we might want to *find and plot multiple paths from a user to an account with different privileges*.
 Or we might want to extend our model with more fine grained resources that are connected to accounts
-and analyze paths from users to these resources (see the [PMapper](https://github.com/nccgroup/PMapper) project that models the IAM data in a more detailed way). The key takeaway is this: graph visualizations can be very powerful to analyze cloud permission data and embedding Kùzu into your applications
+and analyze paths from users to these resources (see the [PMapper](https://github.com/nccgroup/PMapper) project that models the IAM data in a more detailed way). The key takeaway is this: graph visualizations can be very powerful to analyze cloud permission data and embedding Kuzu into your applications
 to develop tools like IAMGraphViz is extremely easy and fun 🥳🙌💪!
 

--- a/src/content/post/2023-08-16-kuzu-v-0.0.7.md
+++ b/src/content/post/2023-08-16-kuzu-v-0.0.7.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.0.7-release"
-title: "Kùzu 0.0.7 Release"
-description: "Release announcement for Kùzu 0.0.7"
+title: "Kuzu 0.0.7 Release"
+description: "Release announcement for Kuzu 0.0.7"
 pubDate: "August 16 2023"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -9,7 +9,7 @@ authors: ["team"]
 tags: ["udf", "macro", "data-type", "performance", "node-group"]
 ---
 
-We are very happy to release Kùzu 0.0.7 today! This release comes with the following new main features and improvements: 
+We are very happy to release Kuzu 0.0.7 today! This release comes with the following new main features and improvements: 
 To install the new version, please visit the [download section of our website](https://kuzudb.com/#download) 
 and [getting started guide](//docs.kuzudb.com/getting-started/). The full
 [release notes are here](https://github.com/kuzudb/kuzu/releases). 
@@ -34,7 +34,7 @@ See more details on supported macro expression types [here](//docs.kuzudb.com/cy
 ### C++ UDFs
 We are also introducing two C++ interfaces, `createScalarFunction` and `createVectorizedFunction` in the `Connection` class of the [C++ API](//docs.kuzudb.com/getting-started/cpp) to define both scalar and vectorized [UDFs](//docs.kuzudb.com/client-apis/cpp-api/udf/).
 
-`createScalarFunction` provides a way for users to define scalar functions in C++ and use it in Kùzu as if they're built-in functions.
+`createScalarFunction` provides a way for users to define scalar functions in C++ and use it in Kuzu as if they're built-in functions.
 Here is an example of a unary scalar function that increments the input value by 5:
 
 ```cpp
@@ -84,7 +84,7 @@ See [our doc here](//docs.kuzudb.com/cypher/data-manipulation-clauses/merge) for
 
 ### Multi-label Set/Delete
 
-Kùzu now allows set/delete on nodes and relationship variables that can be binding to multiple labels. For example,
+Kuzu now allows set/delete on nodes and relationship variables that can be binding to multiple labels. For example,
 to delete all nodes in database (assuming all edges have been deleted).
 
 ```cypher
@@ -133,7 +133,7 @@ See our docs in [Set](//docs.kuzudb.com/cypher/data-manipulation-clauses/set) an
 
 ### Return with `.*`
 
-Kùzu now provides syntactic sugar for returning all properties of a node or relationship with `*.`
+Kuzu now provides syntactic sugar for returning all properties of a node or relationship with `*.`
 
 ```cypher
 MATCH (a:User) RETURN a.*;
@@ -153,7 +153,7 @@ MATCH (a:User) RETURN a.*;
 See [our doc here](//docs.kuzudb.com/cypher/query-clauses/return#returning-node-and-relationship-properties) for more details.
 
 ## Data Export
-Kùzu now supports exporting query results to CSV files using the `COPY TO` command. For example the following
+Kuzu now supports exporting query results to CSV files using the `COPY TO` command. For example the following
 `COPY TO` statement could return the below CSV file.
 
 ```cypher
@@ -186,7 +186,7 @@ RETURN map([1, 2], ['a', 'b']) AS m;
 See [map](//docs.kuzudb.com/cypher/data-types/map) for more information.
 
 ### UNION
-Kùzu's `UNION` is implemented by taking DuckDB's `UNION` type as a reference. Similar to C++ `std::variant`, `UNION` is a nested data type that is capable of holding multiple alternative values with different types. The value under key "tag" is considered as the value being currently hold by the `UNION`.
+Kuzu's `UNION` is implemented by taking DuckDB's `UNION` type as a reference. Similar to C++ `std::variant`, `UNION` is a nested data type that is capable of holding multiple alternative values with different types. The value under key "tag" is considered as the value being currently hold by the `UNION`.
 
 See [union](//docs.kuzudb.com/cypher/data-types/union) for more information.
 

--- a/src/content/post/2023-08-28-kuzu-v-0.0.8.md
+++ b/src/content/post/2023-08-28-kuzu-v-0.0.8.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.0.8-release"
-title: "Kùzu 0.0.8 Release"
-description: "Release announcement for Kùzu 0.0.8"
+title: "Kuzu 0.0.8 Release"
+description: "Release announcement for Kuzu 0.0.8"
 pubDate: "August 28 2023"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -9,7 +9,7 @@ authors: ["team"]
 tags: ["cypher", "data-type", "performance"]
 ---
 
-We're here to introduce Kùzu 0.0.8, which is a minor bug-fix release together with some performance optimizations:
+We're here to introduce Kuzu 0.0.8, which is a minor bug-fix release together with some performance optimizations:
 
 - Fixed a major bug in COPY on large datasets. [PR 1963](https://github.com/kuzudb/kuzu/pull/1963)
 - Implemented the [TopK optimization](https://github.com/kuzudb/kuzu/pull/1949), significantly enhancing the performance of queries that involve ORDER BY and LIMIT clauses. We will delve deeper into this optimization in a blog post. [PR 1949](https://github.com/kuzudb/kuzu/pull/1949)

--- a/src/content/post/2023-10-02-kuzu-v-0.0.9.md
+++ b/src/content/post/2023-10-02-kuzu-v-0.0.9.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.0.9-release"
-title: "Kùzu 0.0.9 Release"
-description: "Release announcement for Kùzu 0.0.9"
+title: "Kuzu 0.0.9 Release"
+description: "Release announcement for Kuzu 0.0.9"
 pubDate: "October 02 2023"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -9,12 +9,12 @@ authors: ["team"]
 tags: ["cypher", "data-type", "performance"]
 ---
 
-We are very happy to release Kùzu 0.0.9 today! This release comes with the following new main features and improvements:
+We are very happy to release Kuzu 0.0.9 today! This release comes with the following new main features and improvements:
 
 ## New Features
 
 ### Load From
-Kùzu now supports loading directly from a file without importing into the database through the `LOAD FROM` clause. For instance, the following query counts the number of rows whose first column starts with 'Adam'.
+Kuzu now supports loading directly from a file without importing into the database through the `LOAD FROM` clause. For instance, the following query counts the number of rows whose first column starts with 'Adam'.
 
 ```cypher
 LOAD FROM "user.csv"
@@ -33,7 +33,7 @@ Details can be found in the [LOAD FROM documentation page](//docs.kuzudb.com/cyp
 
 #### Header Schema
 
-By default, Kùzu will read the header of the file to detect column names and types. If no header is available it will use auto-generated names and all columns will be strings. To manually specify the header, you can use `LOAD WITH HEADERS ... FROM ...`.
+By default, Kuzu will read the header of the file to detect column names and types. If no header is available it will use auto-generated names and all columns will be strings. To manually specify the header, you can use `LOAD WITH HEADERS ... FROM ...`.
 
 For example, the following query will load `name` as a string type for the first column and `age` as an INT64 type for the second column.
 
@@ -43,7 +43,7 @@ WHERE name =~ 'Adam*'
 RETURN name, age;
 ```
 
-If a header is manually specified, Kùzu will try to cast to the given type and throw exceptions if casting fails. More information can be found [here](//docs.kuzudb.com/cypher/load_from).
+If a header is manually specified, Kuzu will try to cast to the given type and throw exceptions if casting fails. More information can be found [here](//docs.kuzudb.com/cypher/load_from).
 
 ### Transaction Statement
 This release replaces the `beginReadTransaction()`, `beginWriteTransaction()`, `commit()` and `rollback()` APIs in all language bindings with explicit statements.
@@ -78,7 +78,7 @@ CALL SHOW_TABLES() RETURN *;
 ```
 
 ### Recursive Relationship Projection
-This release expands recursive relationship patterns and enables projection on intermediate nodes and relationships. Previously, Kùzu only supported returning all node and relationship properties on the path.
+This release expands recursive relationship patterns and enables projection on intermediate nodes and relationships. Previously, Kuzu only supported returning all node and relationship properties on the path.
 
 ```cypher
 MATCH (a:User)-[e:Follows*1..2 (r, n | WHERE r.since > 2020)]->(b:User)
@@ -87,7 +87,7 @@ RETURN nodes(e), rels(e);
 
 This incurs a significant computational overhead when a user is only interested in a subset of properties on the path. Also, returning all properties makes the result harder to interpret.
 
-Kùzu now allows projection inside recursive relationship patterns using a list-comprehension-like syntax.
+Kuzu now allows projection inside recursive relationship patterns using a list-comprehension-like syntax.
 
 ```cypher
 MATCH (a:User)-[e:Follows*1..2 (r, n | WHERE r.since > 2020 | {r.since}, {n.name})]->(b:User)

--- a/src/content/post/2023-10-14-kuzu-v-0.0.10.md
+++ b/src/content/post/2023-10-14-kuzu-v-0.0.10.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.0.10-release"
-title: "Kùzu 0.0.10 Release"
-description: "Release announcement for Kùzu 0.0.10"
+title: "Kuzu 0.0.10 Release"
+description: "Release announcement for Kuzu 0.0.10"
 pubDate: "October 14 2023"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -9,7 +9,7 @@ authors: ["team"]
 tags: ["cypher", "data-type"]
 ---
 
-We're happy to introduce Kùzu 0.0.10, which is a minor release with a bunch of bug fixes and improvements:
+We're happy to introduce Kuzu 0.0.10, which is a minor release with a bunch of bug fixes and improvements:
 - Added the frame of reference encoding for integers. [PR 2140](https://github.com/kuzudb/kuzu/pull/2140)
 - Fixed slicing of UTF-8 string. [PR 2212](https://github.com/kuzudb/kuzu/pull/2212)
 - Fixed copying of invalid UTF-8. [PR 2208](https://github.com/kuzudb/kuzu/pull/2208)

--- a/src/content/post/2023-10-19-kuzu-v-0.0.11.md
+++ b/src/content/post/2023-10-19-kuzu-v-0.0.11.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.0.11-release"
-title: "Kùzu 0.0.11 Release"
-description: "Release announcement for Kùzu 0.0.11"
+title: "Kuzu 0.0.11 Release"
+description: "Release announcement for Kuzu 0.0.11"
 pubDate: "October 19 2023"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -9,6 +9,6 @@ authors: ["team"]
 tags: ["concurrency"]
 ---
 
-Another minor release, Kùzu 0.0.11, is here! The main new feature of this release is read-only access mode for the database on Linux. The read-only mode enables the upcoming [Kùzu UI](https://github.com/kuzudb/kuzu-ui) to optionally open a database in read-only mode while allowing other applications to access the same database concurrently.
+Another minor release, Kuzu 0.0.11, is here! The main new feature of this release is read-only access mode for the database on Linux. The read-only mode enables the upcoming [Kuzu UI](https://github.com/kuzudb/kuzu-ui) to optionally open a database in read-only mode while allowing other applications to access the same database concurrently.
 
 For more detailed information about the changes in this release, please see [here](https://github.com/kuzudb/kuzu/releases/tag/v0.0.11).

--- a/src/content/post/2023-10-25-kuzuexplorer.md
+++ b/src/content/post/2023-10-25-kuzuexplorer.md
@@ -10,7 +10,7 @@ authors: ["chang"]
 tags: ["visualization"]
 ---
 
-Today, we are happy to announce the release of KùzuExplorer, a browser-based frontend for Kùzu to
+Today, we are happy to announce the release of KùzuExplorer, a browser-based frontend for Kuzu to
 visualize and explore database schemas and query results in the form of a graph, table, or in JSON.
 This is a very useful tool for exploring databases and debugging applications during prototyping
 phase. This post describes a brief overview of the main features of KùzuExplorer with pointers to
@@ -52,7 +52,7 @@ about what can be done in the Schema panel can be found [here](https://docs.kuzu
 
 ## Shell Panel: Query Result Visualization
 
-Using KùzuExplorer, you can also issue Cypher queries similar to Kùzu's
+Using KùzuExplorer, you can also issue Cypher queries similar to Kuzu's
 [command line interface](//docs.kuzudb.com/installation#command-line), and
 visualize the results of these queries.
 To issue queries go to the `Shell` tab on the right corner and you can type a Cypher query.

--- a/src/content/post/2023-10-31-kuzu-v-0.0.12.md
+++ b/src/content/post/2023-10-31-kuzu-v-0.0.12.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.0.12-release"
-title: "Kùzu 0.0.12 Release"
-description: "Release announcement for Kùzu 0.0.12"
+title: "Kuzu 0.0.12 Release"
+description: "Release announcement for Kuzu 0.0.12"
 pubDate: "October 31 2023"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -9,6 +9,6 @@ authors: ["team"]
 tags: ["data-type"]
 ---
 
-We release Kùzu 0.0.12, another minor release. This release fixes a bug that prevents the database to be opened in read-only mode on a read-only file system. It also adds support for INT128 data type.
+We release Kuzu 0.0.12, another minor release. This release fixes a bug that prevents the database to be opened in read-only mode on a read-only file system. It also adds support for INT128 data type.
 
 For more detailed information about the changes in this release, please see [here](https://github.com/kuzudb/kuzu/releases/tag/v0.0.12).

--- a/src/content/post/2023-11-19-kuzu-v-0.1.0.md
+++ b/src/content/post/2023-11-19-kuzu-v-0.1.0.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.1.0-release"
-title: "Kùzu 0.1.0 Release"
-description: "Release announcement for Kùzu 0.1.0"
+title: "Kuzu 0.1.0 Release"
+description: "Release announcement for Kuzu 0.1.0"
 pubDate: "November 19 2023"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -9,7 +9,7 @@ authors: ["team"]
 tags: ["cypher", "data-type", "performance", "node-group", "direct-scan"]
 ---
 
-We are very happy to release Kùzu 0.1.0 today! This is a major release with the following set of new features and improvements:
+We are very happy to release Kuzu 0.1.0 today! This is a major release with the following set of new features and improvements:
 
 ## NodeGroup-Based Storage
 
@@ -42,7 +42,7 @@ The offset and index columns are bitpacked in the manner of integer columns.
 Here is a micro-benchmark using the Comment table in LDBC100. To compare the compression rate of each column individually,
 we construct a new table `Tx` for each string column `x` in the Comment table, e.g., `Browser Used`. Tx consists of the
 column x and a serial primary key, which allows us to avoid storing any materialized hash index. We report the size of the `data.kz` file
-and compare against a previous version v0.0.10 of Kùzu.
+and compare against a previous version v0.0.10 of Kuzu.
 
 | Column | Version 0.0.10 | Version 0.1.0 | Difference |
 |---------------|----------------|----------------|------------------|
@@ -146,7 +146,7 @@ of this feature can be found [here](//docs.kuzudb.com/cypher/copy).
 
 #### Detach Delete
 
-Kùzu now supports Cypher's [DETACH DELETE](//docs.kuzudb.com/cypher/data-manipulation-clauses/delete#detach-delete) clause,
+Kuzu now supports Cypher's [DETACH DELETE](//docs.kuzudb.com/cypher/data-manipulation-clauses/delete#detach-delete) clause,
 which deletes a node and all of its relationships together.
 Previously users could only use the `DELETE` command, which deleted nodes that had no relationships.
 For example, the following query deletes a `User` node with `name` Adam and all of its edges.
@@ -219,8 +219,8 @@ Finally, we now have support for 16-byte signed huge integers.
 ## Development
 
 ### Nightly Build
-We have setup a nightly build pipeline for Kùzu users who want to access our latest feature set.
-Here is how you can use the latest nightly version of Kùzu:
+We have setup a nightly build pipeline for Kuzu users who want to access our latest feature set.
+Here is how you can use the latest nightly version of Kuzu:
 
 - For the Python API, the latest nightly version can be installed with `pip install --pre kuzu`.
 - For the Node.js API, the latest nightly version can be installed with `npm i kuzu@next`.
@@ -240,8 +240,8 @@ For example, on a MacOS arm64 platform, these two improvements achieve the follo
 Stripping of our other libraries (e.g. Python) is a work in progress.
 
 ## Closing Remarks
-As usual, we would like to thank everyone in the Kùzu engineering team, especially our interns, for making this release possible.
+As usual, we would like to thank everyone in the Kuzu engineering team, especially our interns, for making this release possible.
 We look forward to your feedback!
 
-Enjoy Kùzu v 0.1.0 and the upcoming holiday season, which in this part of the world 🇨🇦🇨🇦 coincides with
+Enjoy Kuzu v 0.1.0 and the upcoming holiday season, which in this part of the world 🇨🇦🇨🇦 coincides with
 coming of the cold but cozy winter 🤗🤗.

--- a/src/content/post/2024-01-04-llms-graphs-part-1.md
+++ b/src/content/post/2024-01-04-llms-graphs-part-1.md
@@ -132,7 +132,7 @@ I'll show next.
 If you have been following the developments in the LLM space, you will not be surprised to hear that nowadays people build 
 Q&A systems that convert $Q_{NL}$ to a high-level query language using two common tools:
 (i) [LangChain](https://www.langchain.com/); and (ii) [LlamaIndex](https://www.llamaindex.ai/).
-The same tools also integrate with the underlying storage system to load and retrieve your data. To make this more concrete, let me review the [Kùzu-LangChain integration](https://python.langchain.com/docs/use_cases/graph/graph_kuzu_qa), which is similar to the integrations of other GDBMSs. You as a programmer have very little to do: you prepare your Kùzu
+The same tools also integrate with the underlying storage system to load and retrieve your data. To make this more concrete, let me review the [Kuzu-LangChain integration](https://python.langchain.com/docs/use_cases/graph/graph_kuzu_qa), which is similar to the integrations of other GDBMSs. You as a programmer have very little to do: you prepare your Kuzu
 database `db` and load your data into it, wrap it around a `KuzuGraph` and `KuzuQAChain` objects in Python and you have
 a text-to-Cypher pipeline:
 
@@ -193,12 +193,12 @@ You ultimately construct a string prompt that contains $Q_{NL}$, some
 instructions, and schema of the database, and the LLM will generate a query for you. 
 The `KuzuGraph` and `KuzuQAChain` are simple wrappers to do just that.
 If you want to play around with how well this works on other datasets,
-we have this pipeline implemented in Kùzu's browser frontend [KùzuExplorer](//docs.kuzudb.com/kuzuexplorer/). 
+we have this pipeline implemented in Kuzu's browser frontend [KùzuExplorer](//docs.kuzudb.com/kuzuexplorer/). 
 
-That is, for any database you have in Kùzu, you get a natural language interface over it in
+That is, for any database you have in Kuzu, you get a natural language interface over it in
 KùzuExplorer (just click the "robot icon" on the left panel). 
-You can develop similar pipelines with other GDBMSs using similar interfaces (*though I recommend using Kùzu as it will be the
-simplest to get started* 😉: *Unlike other GDBMSs, Kùzu is embeddable and requires no server set up*).
+You can develop similar pipelines with other GDBMSs using similar interfaces (*though I recommend using Kuzu as it will be the
+simplest to get started* 😉: *Unlike other GDBMSs, Kuzu is embeddable and requires no server set up*).
 If you instead want to build Q&A systems over your RDBMSs, you can use
 LangChain's [SQLDatabaseChain](https://python.langchain.com/docs/use_cases/qa_structured/sql#case-2-text-to-sql-query-and-execution) and 
 [SQLAgent](https://python.langchain.com/docs/use_cases/qa_structured/sql#case-3-sql-agents) or

--- a/src/content/post/2024-01-15-llms-graphs-part-2.md
+++ b/src/content/post/2024-01-15-llms-graphs-part-2.md
@@ -225,7 +225,7 @@ is implemented in the examples used in LlamaIndex's documentations using [LlamaI
 
 ![](/img/2024-01-15-llms-graphs-part-2/triples-based-rag-overview.png)
 
-The triples are stored in a GDBMS. You can use a [LlamaIndex GraphStore](https://docs.llamaindex.ai/en/stable/community/integrations/graph_stores.html) for this and Kùzu has an implementation; see the [KuzuGraphStore demo here](https://docs.llamaindex.ai/en/stable/examples/index_structs/knowledge_graph/KuzuGraphDemo.html). The system extract entities using $Q_{NL}$, using some
+The triples are stored in a GDBMS. You can use a [LlamaIndex GraphStore](https://docs.llamaindex.ai/en/stable/community/integrations/graph_stores.html) for this and Kuzu has an implementation; see the [KuzuGraphStore demo here](https://docs.llamaindex.ai/en/stable/examples/index_structs/knowledge_graph/KuzuGraphDemo.html). The system extract entities using $Q_{NL}$, using some
 entity or keyword extractor. In the LlamaIndex demos, this is done by using an LLM. Specifically,
 LLM is prompted with the following [prompt](https://github.com/run-llama/llama_index/blob/ce82bd42329b56bca2a6a44e0f690ebedaf1f002/llama_index/prompts/default_prompts.py#L147): `A question is provided below. Given the question, extract up to {max_keywords}
 keywords from the text....` etc. These keywords are used

--- a/src/content/post/2024-01-24-transforming-your-data-to-graphs-1.md
+++ b/src/content/post/2024-01-24-transforming-your-data-to-graphs-1.md
@@ -1,7 +1,7 @@
 ---
 slug: "transforming-your-data-to-graphs-1"
 title: "Transforming your data to graphs - Part 1"
-description: "Graph thinking for relational data, and the ETL workflow in Kùzu"
+description: "Graph thinking for relational data, and the ETL workflow in Kuzu"
 pubDate: "January 24 2024"
 heroImage: "/img/2024-01-24-transforming-your-data-1/edge_tables.png"
 categories: ["tutorial"]
@@ -14,7 +14,7 @@ the core data structures used to model application data in two broad classes of 
 relational DBMSs (RDBMS) and graph DBMSs (GDBMS).
 
 In this post, we'll look at how to transform data that might exist in a typical relational system
-to a graph and load it into a Kùzu database. The aim of this post and the next one is to showcase
+to a graph and load it into a Kuzu database. The aim of this post and the next one is to showcase
 "graph thinking"[^1], where you explore connections in your existing structured data and apply
 it to potentially uncover new insights.
 
@@ -38,7 +38,7 @@ pattern will find all possible relationships between nodes with names Alice and 
 suitable to express queries for a variety of standard data analytics tasks, it is arguably not as
 suitable when it comes to expressing queries with recursive joins or those that describe complex
 patterns — they are expressed more naturally as paths or graph patterns. Graph queries
-in a well-designed GDBMS like Kùzu contain [specialized syntaxes](https://en.wikipedia.org/wiki/Kleene_star)
+in a well-designed GDBMS like Kuzu contain [specialized syntaxes](https://en.wikipedia.org/wiki/Kleene_star)
 and operators for these types of query workloads.
 
 For a much more detailed description on the benefits of graph modeling and GDBMSs, see our earlier
@@ -97,20 +97,20 @@ explicit name `TransactedWith`.
 
 ### Transforming relational data to graphs
 
-A key feature of Kùzu is that it's a **schema-based** graph database, making it
-highly convenient to read data that already exists in relational systems. Like RDBMSs, Kùzu also relies
+A key feature of Kuzu is that it's a **schema-based** graph database, making it
+highly convenient to read data that already exists in relational systems. Like RDBMSs, Kuzu also relies
 on strongly-typed values in columns and uses primary key constraints on tables to model the data.
-The only difference is that Kùzu uses separate node and edge tables, which we'll show how to
+The only difference is that Kuzu uses separate node and edge tables, which we'll show how to
 create below.
 
-> As such, Kùzu can be viewed as a relational system that provides graph
+> As such, Kuzu can be viewed as a relational system that provides graph
 > modeling capabilities over your tables, allowing you to express graph-based paths and patterns very
-> efficiently in Cypher, the query language implemented by Kùzu.
+> efficiently in Cypher, the query language implemented by Kuzu.
 
 
 In this post, for simplicity, we'll assume that the tables we showed in the relational schema are available
 as CSV files in the `data` directory. The `load_data.py` script will transform and load the
-data into a Kùzu database, while the `query.py` file will run some simple queries to test that
+data into a Kuzu database, while the `query.py` file will run some simple queries to test that
 the load was successful.
 
 ```bash
@@ -128,8 +128,8 @@ the load was successful.
 ### Node tables
 
 The data in the `client.csv`, `city.csv`, `company.csv` and `merchant.csv` files are already in the
-right structure for Kùzu to load them as node tables. You can create the node tables using the
-following Cypher queries and run them via the Kùzu CLI, or the client SDK of your choice.
+right structure for Kuzu to load them as node tables. You can create the node tables using the
+following Cypher queries and run them via the Kuzu CLI, or the client SDK of your choice.
 
 ```cypher
 // Client node table
@@ -170,7 +170,7 @@ CREATE NODE TABLE Merchant(
 )
 ```
 
-Note that `PRIMARY KEY` constraints are required on every node table in Kùzu, as they are used to
+Note that `PRIMARY KEY` constraints are required on every node table in Kuzu, as they are used to
 ensure that edges are always created on unique node pairs. In this case, we use the `client_id`,
 `city_id`, `company_id` and `merchant_id` columns as the primary keys for each respective table.
 
@@ -212,7 +212,7 @@ used to connect the nodes based on the values that match a primary key constrain
 
 The data for the edges require minor transformations to the existing CSV files in which the first
 and second columns respectively represent the `FROM` and `TO` nodes' primary keys. To help reduce
-the amount of custom code you have to write, Kùzu provides convenient APIs to
+the amount of custom code you have to write, Kuzu provides convenient APIs to
 scan/read from CSV files and to copy data from CSV files to a node or edge table. An example is
 shown below.
 
@@ -266,7 +266,7 @@ TO 'located_in.csv';
 
 With all the input files in place, we can now proceed to insert the data and build the graph!
 
-## Insert data into Kùzu
+## Insert data into Kuzu
 
 Collecting all the above functions, we can write a script that performs the following:
 
@@ -292,13 +292,13 @@ COPY LocatedIn FROM 'located_in.csv'
 ```
 
 The queries above require that the empty tables were created beforehand. The `COPY <edge_table> FROM <file>` statement
-writes the data into a Kùzu database. Running the queries on an existing database connection
+writes the data into a Kuzu database. Running the queries on an existing database connection
 results in the graph being saved to a local directory.
 
 ## Querying the graph
 
 We then run some simple queries to test that the data was loaded correctly. We can either create
-a standalone script using the client SDK of your choice, or fire up a [Kùzu CLI](//docs.kuzudb.com/getting-started/cli)
+a standalone script using the client SDK of your choice, or fire up a [Kuzu CLI](//docs.kuzudb.com/getting-started/cli)
 shell and run some Cypher queries.
 
 The first query finds all the clients who transacted with the merchants of "Starbucks".
@@ -372,7 +372,7 @@ as patterns and paths (possibly recursive ones), with an intuitive syntax.
 
 Running Cypher queries in a shell editor is great during initial testing, but on completion, obtaining visual
 feedback is very useful in refining the data model. In a recent blog post, we introduced
-[Kùzu Explorer](../kuzuexplorer), a browser-based frontend that allows
+[Kuzu Explorer](../kuzuexplorer), a browser-based frontend that allows
 users to visualize their graph data and run queries interactively.
 
 The explorer is currently only accessible via Docker, but a standalone application is on the way. To visualize
@@ -389,7 +389,7 @@ You can then see a query editor in your browser at `http://localhost:8000`.
 
 ### Verify schema
 
-In the Kùzu explorer window on the browser, click on the `Schema` tab on the top right.
+In the Kuzu explorer window on the browser, click on the `Schema` tab on the top right.
 
 ![](/img/2024-01-24-transforming-your-data-1/kuzu_schema_viz.png)
 
@@ -414,10 +414,10 @@ It's possible to customize the visual style of the graph by clicking on the `Set
 ## Conclusions
 
 The aim of this blog post is to show how to transform data that might exist in a typical relational
-system to a graph and load it into a Kùzu database. We also show how to visualize the graph and
+system to a graph and load it into a Kuzu database. We also show how to visualize the graph and
 run some simple queries to test our data model.
 
-What's important to take away from this exercise is that using a graph database like Kùzu for the
+What's important to take away from this exercise is that using a graph database like Kuzu for the
 kinds of queries we ran above makes a **lot** of sense. The raw transaction data that may have been
 sitting in an RDBMS system wasn't simple to reason about when it came to answering questions
 about connected entities. Doing so in SQL would have required multiple joins and subqueries, whereas
@@ -427,12 +427,12 @@ benefit from a graph data model, and there are many cases where SQL and RDBMS ar
 Another key takeaway is that designing a graph data model is an
 *iterative* exercise. You may not get it right the first time, and that's okay! The key is to have
 a good understanding of the data and the questions you want to answer, and to keep refining the
-model as you learn more about the data. Using an embeddable solution like Kùzu is really helpful
+model as you learn more about the data. Using an embeddable solution like Kuzu is really helpful
 in this regard, as you can quickly load the data and test your queries without having to worry
 about setting up servers or authentication.
 
 In the [next post](../transforming-your-data-to-graphs-2), we'll look at a larger dataset of a similar nature, to answer more complex
-questions about disputed transactions. In the meantime, give [Kùzu](https://github.com/kuzudb/kuzu)
+questions about disputed transactions. In the meantime, give [Kuzu](https://github.com/kuzudb/kuzu)
 a try out on your own data, and begin thinking about whether knowledge graphs are a good fit for
 your use case!
 
@@ -440,7 +440,7 @@ your use case!
 
 The code to reproduce the workflow shown in this post can be found in the
 [graphdb-demo](https://github.com/kuzudb/graphdb-demo/tree/main/src/python/transactions) repository.
-It uses Kùzu's Python API, but you are welcome to use the client API [of your choice](//docs.kuzudb.com/client-apis).
+It uses Kuzu's Python API, but you are welcome to use the client API [of your choice](//docs.kuzudb.com/client-apis).
 
 ## Further reading
 

--- a/src/content/post/2024-02-08-kuzu-v-0.2.0.md
+++ b/src/content/post/2024-02-08-kuzu-v-0.2.0.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.2.0-release"
-title: "Kùzu 0.2.0 Release"
-description: "Release announcement for Kùzu 0.2.0"
+title: "Kuzu 0.2.0 Release"
+description: "Release announcement for Kuzu 0.2.0"
 pubDate: "February 08 2024"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -9,17 +9,17 @@ authors: ["team"]
 tags: ["cypher", "rdf", "extensions"]
 ---
 
-We are very happy to announce the release of Kùzu 0.2.0! This is a major release with two major new features:
-(i) RDFGraphs; and (ii) Kùzu extensions framework and our first extension for accessing files over HTTP(S) servers and on S3.
-We also have a set of improvements at the core that should make Kùzu faster behind the scenes and several other
+We are very happy to announce the release of Kuzu 0.2.0! This is a major release with two major new features:
+(i) RDFGraphs; and (ii) Kuzu extensions framework and our first extension for accessing files over HTTP(S) servers and on S3.
+We also have a set of improvements at the core that should make Kuzu faster behind the scenes and several other
 improvements, as discussed below.
 
 For details on all the changes in this release, please see the [change log of this release](https://github.com/kuzudb/kuzu/releases).
 
 ## RDFGraphs
-Kùzu's native data model is a version of the property graph model, where you model your records as a set of entities/nodes and relationships
-and properties on nodes and relationships. Kùzu's version of
-property graphs is, in fact, a *structured property graph model*, as Kùzu requires you to pre-specify the properties on
+Kuzu's native data model is a version of the property graph model, where you model your records as a set of entities/nodes and relationships
+and properties on nodes and relationships. Kuzu's version of
+property graphs is, in fact, a *structured property graph model*, as Kuzu requires you to pre-specify the properties on
 your nodes and relationships. This is very close to the relational model. The primary difference is that 
 you specify some of your tables as node tables and others as relationship tables. 
 
@@ -31,22 +31,22 @@ In contrast to the property graph model, RDF is particularly suitable for more f
 All information, including the actual data as well as the schema of your data, i.e., metadata, 
 is represented homogeneously in the form of (subject, predicate, object) *triples*.
 
-Kùzu 0.2.0 introduces native support for RDF through a new extension of its data model called [*RDFGraphs*](//docs.kuzudb.com/rdf-graphs/example-rdfgraph).
-RDFGraphs is a lightweight extension to Kùzu's data model that allows ingesting triples natively into Kùzu so
+Kuzu 0.2.0 introduces native support for RDF through a new extension of its data model called [*RDFGraphs*](//docs.kuzudb.com/rdf-graphs/example-rdfgraph).
+RDFGraphs is a lightweight extension to Kuzu's data model that allows ingesting triples natively into Kuzu so
 that they can be queried using Cypher. 
 It is a lightweight extension because an RDFGraph is simply a wrapper around
-2 node and 2 relationship tables that acts as a new object in Kùzu's data model.
+2 node and 2 relationship tables that acts as a new object in Kuzu's data model.
 For example you can `CREATE/DROP RDFGraph  <rdfgraph-name>` to create or drop an RDFGraph, which will
 create or drop four underlying tables. You can  then query these underlying tables with Cypher.
 Therefore, RDFGraphs are a specific mapping of your triples into
-Kùzu's native property graph data model, so that you can benefit from Kùzu's easy, scalable, and fast querying capabilities 
+Kuzu's native property graph data model, so that you can benefit from Kuzu's easy, scalable, and fast querying capabilities 
 for basic querying of RDF triples.
 
-**In short, you can now use Kùzu to store and query RDF data via Cypher!**
+**In short, you can now use Kuzu to store and query RDF data via Cypher!**
 
 This release is an important step in our vision to be the
 go-to system to model your records as graphs. Here is the example from our [documentation](//docs.kuzudb.com/rdf-graphs/example-rdfgraph) 
-of how you can use Kùzu to store and query RDF data.
+of how you can use Kuzu to store and query RDF data.
 Consider a Turtle file `uni.ttl` modeling information about university students, faculty and cities they live in:
 
 ```cypher
@@ -94,8 +94,8 @@ Learn all about RDFGraphs, how to CREATE them, how to import triples into them f
 the property graph node and relationships they map to, how to query and modify them and all in [our documentation page for RDFGraphs](//docs.kuzudb.com/rdf-graphs/).
 
 ## Extensions framework
-Kùzu 0.2.0 introduces a new framework for extending Kùzu's capabilities, similar to PostreSQL's and DuckDB's extensions.
-[Extensions](//docs.kuzudb.com/extensions/) are a way to add new features to Kùzu without modifying the core code.
+Kuzu 0.2.0 introduces a new framework for extending Kuzu's capabilities, similar to PostreSQL's and DuckDB's extensions.
+[Extensions](//docs.kuzudb.com/extensions/) are a way to add new features to Kuzu without modifying the core code.
 The 0.2.0 version is just the beginning of our development of this framework, and we are happy to release our first extension, `httpfs`,
 which supports reading data from a file hosted on an HTTP(S) server. `httpfs` can also be used to read from Amazon S3.
 You can use the `httpfs` extension by installing it and dynamically loading it as follows:
@@ -129,12 +129,12 @@ We have plans to implement additional extensions, such as to support new data ty
 
 ## Improvements at the Core
 
-We are also continuing non-stop to make the core of Kùzu faster and more efficient. We have improved our hash index
+We are also continuing non-stop to make the core of Kuzu faster and more efficient. We have improved our hash index
 building by parallelizing it (other parts of the copy pipeline were already parallelized) 
 and through several other optimizations. This results in an improvement in bulk loading performance.
 Here is a comparison showing by how much we improved bulk loading performance of the LDBC Comments table, which consists of 220M records (~22 GB):
 
-Threads | Kùzu 0.1.0 | Kùzu 0.2.0 | Performance improvement
+Threads | Kuzu 0.1.0 | Kuzu 0.2.0 | Performance improvement
 :---: | ---: | ---: | ---:
 1 | 536.1 | 496.5 | 7.4%
 2 | 289.1 | 257.3 | 11.0%
@@ -143,14 +143,14 @@ Threads | Kùzu 0.1.0 | Kùzu 0.2.0 | Performance improvement
 
 We have also improved our disk-based 
 CSR implementation to make it faster when ingesting data through `CREATE` statements (intended for loading small amounts of data),
-and added constant compression all improving Kùzu's performance in some cases in minor ways.
+and added constant compression all improving Kuzu's performance in some cases in minor ways.
 
 ## Closing Remarks
 In addition to the above, this release includes the following:
 
-* Several additional improvements to Kùzu's command line interface
+* Several additional improvements to Kuzu's command line interface
 * A new UUID data type
 * Many improvements to our testing framework
 
 These updates were all made by our amazing interns 😎. As always, we would like to thank everyone
-in the Kùzu team for making this release possible and look forward to user feedback!
+in the Kuzu team for making this release possible and look forward to user feedback!

--- a/src/content/post/2024-02-23-transforming-your-data-to-graphs-2.md
+++ b/src/content/post/2024-02-23-transforming-your-data-to-graphs-2.md
@@ -10,9 +10,9 @@ tags: ["data-science", "networkx", "graph-algorithms", "analysis"]
 ---
 
 In the [previous post](../transforming-your-data-to-graphs-1), we showed how to transform a
-typical relational data model to a graph data model and load it into a Kùzu database that could
+typical relational data model to a graph data model and load it into a Kuzu database that could
 then be queried via Cypher to answer path-related questions about the data. The aim of this post is
-to show how Kùzu offers numerous tools that allow users to
+to show how Kuzu offers numerous tools that allow users to
 flexibly model and analyze data. We will analyze a transaction network, and
 use a combination of Cypher queries, graph visualization and network analysis to answer questions
 about the data.
@@ -42,7 +42,7 @@ marked after the fact and stored in a separate table.
 
 When considering questions about disputed transactions, aggregation queries are not enough. We need
 to study the paths between the clients, merchants and transactions. This is where a graph
-database like Kùzu is very handy. The data model used by Kùzu is a _structured_ property graph model,
+database like Kuzu is very handy. The data model used by Kuzu is a _structured_ property graph model,
 allowing us to capture the relationships between entities in a more natural way, for specific query
 workloads such as this one.
 
@@ -56,11 +56,11 @@ The transactions are modelled as edges, with an `is_disputed` property to indica
 a transaction is disputed or not. This simplifies the kinds of queries we need to write, and is
 sufficient for our initial analysis.
 
-## Inserting data into Kùzu
+## Inserting data into Kuzu
 
 The [previous post](../2024-01-24-transforming-your-data-1) went into the data transformation
 and ETL aspects, so we won't go over that here. In a nutshell, the following input files exist in CSV
-format that need to be inserted into Kùzu:
+format that need to be inserted into Kuzu:
 
 ```
 .
@@ -78,7 +78,7 @@ format that need to be inserted into Kùzu:
 └── load_data.py
 ```
 
-The script `load_data.py` reads the CSV files and inserts the data into Kùzu using the Python API.
+The script `load_data.py` reads the CSV files and inserts the data into Kuzu using the Python API.
 The result of running this script is a graph whose schema matches that shown in the sketch
 above.
 
@@ -86,10 +86,10 @@ above.
 
 ## Exploratory data analysis
 
-Once the data is loaded into Kùzu, it's very simple to begin exploring the data using Cypher queries
-in one of three ways: i) using a Kùzu CLI shell, ii) using a Jupyter notebook, and iii) using the
-Kùzu Explorer UI. Because the goal of this exercise is to perform exploratory data analysis on the
-graph, we'll [Kùzu Explorer](https://github.com/kuzudb/explorer) to visualize the graph and run Cypher queries.
+Once the data is loaded into Kuzu, it's very simple to begin exploring the data using Cypher queries
+in one of three ways: i) using a Kuzu CLI shell, ii) using a Jupyter notebook, and iii) using the
+Kuzu Explorer UI. Because the goal of this exercise is to perform exploratory data analysis on the
+graph, we'll [Kuzu Explorer](https://github.com/kuzudb/explorer) to visualize the graph and run Cypher queries.
 
 ```cypher
 MATCH (c:Client) RETURN COUNT(c) AS numClients
@@ -147,7 +147,7 @@ WHERE t.is_disputed = true
 RETURN * LIMIT 25;
 ```
 
-When running this query in Kùzu Explorer, we can customize the edge properties displayed in the graph visualization. In
+When running this query in Kuzu Explorer, we can customize the edge properties displayed in the graph visualization. In
 the following image, we mark the `TransactedWith` edges with the boolean value of the `is_disputed`
 property from the data. Only a small fraction of these transactions have the `is_disputed` property
 marked as `true`.
@@ -212,7 +212,7 @@ returned the names of the clients, but in a larger dataset it makes sense to ret
 number of clients instead.
 
 When viewed visually, these results can be quite powerful. The following image shows result from
-above, as seen in Kùzu Explorer.
+above, as seen in Kuzu Explorer.
 
 ![](/img/2024-02-23-transforming-your-data-2/dispute_graph_viz.png)
 
@@ -224,9 +224,9 @@ merchant, located in Boston, could be a source of fraud.
 
 ## Graph algorithms
 
-Kùzu is well-integrated with the PyData ecosystem, including PyTorch Geometric, Pandas, and
+Kuzu is well-integrated with the PyData ecosystem, including PyTorch Geometric, Pandas, and
 [NetworkX](https://networkx.org/documentation/stable/reference/index.html), a popular Python library
-for network analysis. Because Kùzu is an embedded graph database, it runs in-process with a Python
+for network analysis. Because Kuzu is an embedded graph database, it runs in-process with a Python
 application, so it's simple to isolate a subgraph of interest via Cypher and convert it
 to a NetworkX directed graph (DiGraph) for further analysis.
 
@@ -355,7 +355,7 @@ node_id | closeness_centrality
 96 | 0.024000
 
 Once we have the Pandas DataFrame, it's trivial to write a function that can modify the existing
-`Merchant` node table and add the closeness centrality scores back to the graph. Kùzu's Python
+`Merchant` node table and add the closeness centrality scores back to the graph. Kuzu's Python
 API has a native scan feature that can directly read from Pandas DataFrames in a zero-copy manner.
 
 Note that we first alter the original node table schema to add a new column for the closeness
@@ -383,29 +383,29 @@ can help us use these scores in downstream machine learning models, or to inform
 
 ## Conclusions
 
-Hopefully, this post has given you a good idea of how to use Kùzu to effectively model and analyze
+Hopefully, this post has given you a good idea of how to use Kuzu to effectively model and analyze
 your data via a combination of Cypher and graph algorithms. It's worth keeping in mind that
 Graph data science, just like conventional data science, is an iterative
 process. The ability to think of structured data (in tables) as graphs helps us rapidly isolate interesting subsets of the data,
 run graph algorithms and visualize substructures, making these powerful tools in the data scientist's toolkit.
 
-Kùzu's in-process architecture makes it very friendly towards these sorts of workflows without the
-data scientist having to worry about servers or managing infrastructure. Data can be conveniently read into Kùzu from a
+Kuzu's in-process architecture makes it very friendly towards these sorts of workflows without the
+data scientist having to worry about servers or managing infrastructure. Data can be conveniently read into Kuzu from a
 variety of sources, including relational databases, CSV or parquet files, or DataFrames. Future
-versions of Kùzu will support more convenience features, such as the ability to natively scan
+versions of Kuzu will support more convenience features, such as the ability to natively scan
 PostgreSQL tables, as well as native support for Arrow tables.
 
 In summary, the interoperability of an embedded graph database with popular Python libraries like
-NetworkX and Pandas makes Kùzu a powerful tool for graph data science. If you have data of a similar
+NetworkX and Pandas makes Kuzu a powerful tool for graph data science. If you have data of a similar
 nature in the form of relational tables, we highly recommend you to
-think about whether your use case can benefit from graph data models. If so, give Kùzu a try and
+think about whether your use case can benefit from graph data models. If so, give Kuzu a try and
 reach out to us on [Discord](https://discord.gg/VtX2gw9Rug) with your experiences and feedback!
 
 ## Code
 
 The code to reproduce the workflow shown in this post can be found in the
 [graphdb-demo](https://github.com/kuzudb/graphdb-demo/tree/main/src/python/transactions_with_disputes) repository.
-It uses Kùzu's Python API, but you are welcome to use the client API [of your choice](//docs.kuzudb.com/client-apis).
+It uses Kuzu's Python API, but you are welcome to use the client API [of your choice](//docs.kuzudb.com/client-apis).
 
 ## Further reading
 

--- a/src/content/post/2024-03-28-in-praise-of-rdf.md
+++ b/src/content/post/2024-03-28-in-praise-of-rdf.md
@@ -24,7 +24,7 @@ RDF can even play an increasingly important role in the era of LLM-based applica
 I will also discuss some fascinating topics in AI that intersect with databases:
 logic, reasoning, and knowledge representation systems. 
 I also put in a minor plug at the end for a new feature we added called [RDFGraphs](https://docs.kuzudb.com/rdf-graphs/),
-to import and query RDF data in Kùzu.
+to import and query RDF data in Kuzu.
 
 
 ---
@@ -52,9 +52,9 @@ to import and query RDF data in Kùzu.
   here is a [great article](https://arxiv.org/ftp/arxiv/papers/2308/2308.04445.pdf) 
   by the late [Douglas Lenat](https://en.wikipedia.org/wiki/Douglas_Lenat).
 
-- **Kùzu RDFGraphs**: [RDFGraphs](https://docs.kuzudb.com/rdf-graphs/) is a new feature in Kùzu to map RDF triples into Kùzu's structured property graph model.
+- **Kuzu RDFGraphs**: [RDFGraphs](https://docs.kuzudb.com/rdf-graphs/) is a new feature in Kuzu to map RDF triples into Kuzu's structured property graph model.
   This way you can query RDF datasets in Cypher, enhance them with property graph data, and benefit from
-  Kùzu's fast query processor.
+  Kuzu's fast query processor.
 ---
 
 [^1]: Several terms are used for systems that manage RDF and provide a high-level query language over them.
@@ -195,7 +195,7 @@ RDF as a knowledge representation system, you can skip to the [next part](#rdf-a
 I want to describe a mental framework of data models that I find helpful when comparing them. 
 Let's focus on the relational model on the one side and
 the two popular graph-based data models, property graph (PG) and RDF on the other side.
-I am also adding Kùzu's variant of the PG model, which we call the *structured* PG model, into this framework.
+I am also adding Kuzu's variant of the PG model, which we call the *structured* PG model, into this framework.
 The framework is shown in the figure below.
 
 <Image src="/img/2024-03-28-in-praise-of-rdf/data-models.png" width="600" />
@@ -232,21 +232,21 @@ makes the job of a PG DBMS harder. But I still put property graph model higher o
 because in my experience most of the databases users put into PG DBMSs are extracted from relational systems so have 
 inherent structure.
 
-**Note on Kùzu's structured PG model:** Kùzu implements a variant of the property graph data model that we call the *structured* property graph model. This is 
+**Note on Kuzu's structured PG model:** Kuzu implements a variant of the property graph data model that we call the *structured* property graph model. This is 
 more or less equivalent to the relational model, except that we require users to identify their tables as "node" or
 "relationship" tables. That is why this model appears at the same location as the relational model in the figure above.
 This is a conscious choice that we are very happy about.
-We sacrifice some flexibility of the original PG model, e.g., nodes cannot have multiple labels in Kùzu.
+We sacrifice some flexibility of the original PG model, e.g., nodes cannot have multiple labels in Kuzu.
 In return, we can exploit more structure in the data to do faster and more scalable
 query processing. Further, by requiring that tables are identified
 as nodes or relationships, we are able to provide
 a graph-based data model to users and implement Cypher, which has a very nice syntax for 
 expressing paths and several common complex and recursive joins. In fact, I could put
 structured PG higher than the relational model in the figure because by identifying their tables as node vs relationship
-tables, users are telling us something important about their workloads. Specifically, they inform Kùzu
+tables, users are telling us something important about their workloads. Specifically, they inform Kuzu
 that the relationship records will be used to join node records with their "neighbor" node records.
 This is true in other PG DBMSs as well. They also have the same information.
-Kùzu and other GDBMSs exploit this information by building join indices over the relationship tables, 
+Kuzu and other GDBMSs exploit this information by building join indices over the relationship tables, 
 so that common joins of node records with their neighbors can be very fast.
 
 ## RDF as a knowledge representation system
@@ -473,18 +473,18 @@ But there are cases, as I outlined, where you need a model that's more flexible 
 
 I want to end with several notes.
 
-#### A minor plug for Kùzu RDFGraphs
+#### A minor plug for Kuzu RDFGraphs
 
-First, I want to highlight a new feature we introduced in Kùzu called [RDFGraphs](https://docs.kuzudb.com/rdf-graphs/).
-Let me emphasize here that Kùzu's native data model is **not** RDF -- it is structured property graphs. But, part of our mission
+First, I want to highlight a new feature we introduced in Kuzu called [RDFGraphs](https://docs.kuzudb.com/rdf-graphs/).
+Let me emphasize here that Kuzu's native data model is **not** RDF -- it is structured property graphs. But, part of our mission
 is to simplify graph modeling for people and the other part is to develop the most 
 competent GDBMS out there in terms of performance and scalability, which we do by basing our core
 architecture on state-of-the-art data management principles. As part of the former goal, 
 we want people to use
-Kùzu whenever they need to model their records as a graph, whether these records exist in 
+Kuzu whenever they need to model their records as a graph, whether these records exist in 
 CSV files, RDBMSs, or are already in an RDF triple format. In light of this, 
-RDFGraphs is a lightweight extension of our structured property graph model that allows users to map RDF triples into a Kùzu database. Once
-your triples are in Kùzu, you can query them with Cypher (no inference of course), 
+RDFGraphs is a lightweight extension of our structured property graph model that allows users to map RDF triples into a Kuzu database. Once
+your triples are in Kuzu, you can query them with Cypher (no inference of course), 
 and further enhance them with other records you have modeled as a property graph.
 We also have some [pre-loaded RDFGraphs](https://docs.kuzudb.com/rdf-graphs/rdfgraphs-repo) 
 you can download and start playing around with.

--- a/src/content/post/2024-05-02-kuzu-v-0.4.0.md
+++ b/src/content/post/2024-05-02-kuzu-v-0.4.0.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.4.0-release"
-title: "Kùzu 0.4.0 Release"
-description: "Release announcement for Kùzu 0.4.0"
+title: "Kuzu 0.4.0 Release"
+description: "Release announcement for Kuzu 0.4.0"
 pubDate: "May 02 2024"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -11,22 +11,22 @@ draft: false
 ---
 
 With the warmer weather in 🇨🇦 approaching, there's cause for excitement on more than one front - we've just released
-version **0.4.0** of Kùzu! This is a significant release, as it introduces a new storage layer along with
+version **0.4.0** of Kuzu! This is a significant release, as it introduces a new storage layer along with
 a host of additional features, improvements and extensions, detailed in this post. Let's gear up!
 
 ## Features
 
 ### New extensions: Scanning DuckDB and PostgreSQL
 
-The first feature we discuss is great news for users who want to move data from external relational databases to Kùzu,
+The first feature we discuss is great news for users who want to move data from external relational databases to Kuzu,
 but don't want to do additional ETL using intermediate files. Postgres and DuckDB database extensions are here!
 
-In v0.2.0, we introduced the idea of the Kùzu extensions framework and our first extension, `httpfs`. In
-v0.4.0, we are happy to introduce two brand new extensions to connect Kùzu to the following two external databases: DuckDB and PostgreSQL .
+In v0.2.0, we introduced the idea of the Kuzu extensions framework and our first extension, `httpfs`. In
+v0.4.0, we are happy to introduce two brand new extensions to connect Kuzu to the following two external databases: DuckDB and PostgreSQL .
 For now, these extensions are read-only, allowing you to directly scan data from either database (no write support).
 
 Using them is remarkably simple: You first install the required extension and then load it into your
-Kùzu session. The following snippet shows how this is done via the CLI:
+Kuzu session. The following snippet shows how this is done via the CLI:
 
 ```
 INSTALL postgres;
@@ -35,13 +35,13 @@ LOAD EXTENSION postgres;
 
 To use the `duckdb` extension, you would change `postgres` in the above command with `duckdb`. You first
 attach a Postgres database and its associated tables (while providing the necessary connection string parameters)
-to your Kùzu CLI or client session.
+to your Kuzu CLI or client session.
 
 ```
 ATTACH 'dbname=university user=postgres host=localhost password=yourpassword port=5432' AS pg_db_uni (dbtype 'postgres');
 ```
 
-The following Cypher query passes the results from scanning the Postgres `person` table to the `COPY FROM` command in Kùzu, 
+The following Cypher query passes the results from scanning the Postgres `person` table to the `COPY FROM` command in Kuzu, 
 so that you can more easily build graphs from data in external relational databases (using a `LOAD FROM` subquery in a 
 `COPY FROM` statement is also a new feature of this release; [see below](#copy-from-with-subquery)).
 
@@ -50,7 +50,7 @@ CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY (name));
 COPY Person FROM (LOAD FROM pg_db_uni.person RETURN *);
 ```
 
-You can see the attached databases to a given Kùzu session any time with the `show_attached_databases()` call:
+You can see the attached databases to a given Kuzu session any time with the `show_attached_databases()` call:
 
 ```
 CALL show_attached_databases() RETURN *;
@@ -64,15 +64,15 @@ CALL show_attached_databases() RETURN *;
 -----------------------------------
 ```
 
-We are planning to develop more extensions like these in the future to fulfill our vision of using Kùzu to seamlessly
+We are planning to develop more extensions like these in the future to fulfill our vision of using Kuzu to seamlessly
 do graph modeling, querying, and analysis over your raw records wherever they may be residing.
 
 ### Import/Export database
 
-Because our storage layer is still evolving, migrating between Kùzu versions requires manually exporting 
-your old Kùzu database node and relationship tables to CSV or Parquet files and
-then using the newer Kùzu version, creating a new database with the same tables and copying these files back. 
-You can now migrate databases between different Kùzu versions without this manual process.
+Because our storage layer is still evolving, migrating between Kuzu versions requires manually exporting 
+your old Kuzu database node and relationship tables to CSV or Parquet files and
+then using the newer Kuzu version, creating a new database with the same tables and copying these files back. 
+You can now migrate databases between different Kuzu versions without this manual process.
 We have introduced two new commands, `EXPORT DATABASE` and `IMPORT DATABASE`, to streamline this process.
 The `EXPORT DATABASE` command allows you to export the contents of
 the database to a specific directory. The query below exports the database to an absolute path,
@@ -84,7 +84,7 @@ EXPORT DATABASE '/path/to/export' (FORMAT="csv", HEADER=true);
 
 The data is exported to CSV with headers included, but you can also export to
 Parquet, if desired. We also generate several files that contains the Cypher commands needed to
-import the database, including the node and relationship tables and macros, back into Kùzu.
+import the database, including the node and relationship tables and macros, back into Kuzu.
 You can import the database from `/path/to/export` to the database your current CLI or client session
 is connected to with the `IMPORT DATABASE` command:
 
@@ -94,7 +94,7 @@ IMPORT DATABASE '/path/to/export';
 
 ### `COPY FROM` with subquery
 
-`COPY FROM` is Kùzu's fastest way to do bulk insertion of records into node and relationship tables.
+`COPY FROM` is Kuzu's fastest way to do bulk insertion of records into node and relationship tables.
 Previously, this feature could only be used to insert data from raw files, such as CSV or Parquet.
 In v0.4.0, we added support for using subqueries following the `COPY FROM` statement. This feature allows you to
 first perform a task like `MATCH` and then use the results of that query as input to the `COPY FROM` command.
@@ -118,7 +118,7 @@ a Pandas DataFrame and use the results as input to the `COPY FROM` command. This
 predicate filters as follows:
 
 ```python
-# Assumes that you have a Kùzu connection object named `conn`
+# Assumes that you have a Kuzu connection object named `conn`
 # Also assumes that you created a node table named `Person` with columns `name` and `age`
 import pandas as pd
 
@@ -135,9 +135,9 @@ transformation prior to inserting data into the database.
 
 ### Bulk insert into a non-empty table
 
-Recall again that `COPY FROM` is Kùzu's fastest way to insert records into tables.
+Recall again that `COPY FROM` is Kuzu's fastest way to insert records into tables.
 In prior releases, the `COPY FROM` command could only be used to bulk insert data into an empty table.
-This restriction has now been removed. In Kùzu v0.4.0, you can also bulk insert data into a non-empty table,
+This restriction has now been removed. In Kuzu v0.4.0, you can also bulk insert data into a non-empty table,
 making it both easier and faster to append data to an existing table. 
 
 Below, we show an example of how `COPY FROM` might be used in conjunction with the subquery feature described
@@ -161,7 +161,7 @@ you use this approach if you're inserting large amounts of data into your databa
 
 ### Scan from Pandas PyArrow backend
 
-Earlier versions of Kùzu provided the ability to scan data from a Pandas DataFrame using the NumPy backend.
+Earlier versions of Kuzu provided the ability to scan data from a Pandas DataFrame using the NumPy backend.
 In v0.4.0, we added support for PyArrow-backed Pandas DataFrames as well.
 Make sure to run `pip install -U pyarrow pandas` before trying the example below.
 
@@ -178,7 +178,7 @@ df = pd.DataFrame({
     "age": [30, 40, 50, 25]
 }).convert_dtypes(dtype_backend="pyarrow")
 
-# Scan the PyArrow-backed Pandas DataFrame in Kùzu by referencing the DataFrame object
+# Scan the PyArrow-backed Pandas DataFrame in Kuzu by referencing the DataFrame object
 result = conn.execute("LOAD FROM df RETURN *;")
 print(result.get_as_df())
 ```
@@ -191,7 +191,7 @@ print(result.get_as_df())
 3    Noura   25
 ```
 
-How does this work under the hood? Internally, Kùzu uses a similar layout to Apache Arrow's `Array`,
+How does this work under the hood? Internally, Kuzu uses a similar layout to Apache Arrow's `Array`,
 allowing it to perform a [memcpy](https://cplusplus.com/reference/cstring/memcpy/) operation,
 which is more efficient than a conventional copy.
 Using `memcpy` means we directly access the values in the memory blocks of the underlying Arrow objects, avoiding the
@@ -205,7 +205,7 @@ interoperability with other full-fledged Arrow-backed DataFrame libraries (like 
 ### Better integration with Polars
 
 Although this feature came out in a minor release just prior to this one (v0.3.2), it's worth mentioning here.
-Kùzu now allows directly outputting the results of a Cypher query as a Polars DataFrame. The query
+Kuzu now allows directly outputting the results of a Cypher query as a Polars DataFrame. The query
 results are converted to an Arrow table obtained via our `get_as_arrow()`
 method, and then seamlessly passed to a Polars DataFrame via the Polars `from_arrow()` method. This feature
 was made possible thanks to an [external contributor](https://github.com/kuzudb/kuzu/pull/2985)
@@ -234,16 +234,16 @@ that require vector embeddings that are of a pre-determined length.
 
 We also introduced [similarity search functions](https://github.com/kuzudb/kuzu/pull/3087) that operate
 on `ARRAY` types: cosine similarity, dot product, cross product and inner product. This feature is particularly
-useful for users who want to perform search & retrieval using embeddings stored in Kùzu tables.
+useful for users who want to perform search & retrieval using embeddings stored in Kuzu tables.
 
 ## Internal ID compression
 
 We now apply compression to the internal IDs in the storage layer. Internally, for each relationship, we store,
 in each direction, its source and destination node IDs, and a unique relationship ID. All node and relationship
 IDs are represented as internal IDs, and compressed as integer values now.
-Applying compression on internal IDs can result in significant reduction in the size of a Kùzu database. For
+Applying compression on internal IDs can result in significant reduction in the size of a Kuzu database. For
 LDBC SF100, [we observed](https://github.com/kuzudb/kuzu/pull/3116) a **45%** reduction in size for
-the `data.kz` file within the Kùzu database directory.
+the `data.kz` file within the Kuzu database directory.
 
 | Version | Size of `data.kz` for LDBC SF100 |
 | :---: | :---: |
@@ -255,7 +255,7 @@ the `data.kz` file within the Kùzu database directory.
 This post highlighted just a few of the many features and improvements that came along with the 0.4.0 release.
 It's recommended to check out our [release notes](https://github.com/kuzudb/kuzu/releases/tag/v0.4.0) on GitHub for a more comprehensive list.
 
-We are excited to bring these enhancements to the ever-growing Kùzu user community. As always,
-our many thanks go out to everyone in the Kùzu team, including our interns and our external contributors
+We are excited to bring these enhancements to the ever-growing Kuzu user community. As always,
+our many thanks go out to everyone in the Kuzu team, including our interns and our external contributors
 for their excellent work in making this release possible. We encourage you to try out the latest
 release on your own workflows and engage with us on [Discord](https://discord.gg/VtX2gw9Rug)!

--- a/src/content/post/2024-05-14-rdf-shacl-and-kuzu.md
+++ b/src/content/post/2024-05-14-rdf-shacl-and-kuzu.md
@@ -1,7 +1,7 @@
 ---
 slug: "rdf-shacl-and-kuzu"
-title: "Validating RDF data with SHACL in Kùzu"
-description: "Combining RDFLib and SHACL to validate RDF data in Kùzu"
+title: "Validating RDF data with SHACL in Kuzu"
+description: "Combining RDFLib and SHACL to validate RDF data in Kuzu"
 pubDate: "May 14 2024"
 heroImage: "/img/rdf-shacl-kuzu/rdf-running-example.png"
 categories: ["example"]
@@ -11,14 +11,14 @@ draft: false
 ---
 
 The Resource Description Framework (RDF) model, along with property graphs, is one of the most popular
-graph data models used in practice[^1]. In this post, we will explore how you can work with RDF data in Kùzu
+graph data models used in practice[^1]. In this post, we will explore how you can work with RDF data in Kuzu
 using [RDFLib](https://rdflib.readthedocs.io/en/stable/) and [pySHACL](https://github.com/RDFLib/pySHACL).
-We will demonstrate how to load this data into Kùzu, write SHACL shape constraints to validate the data,
-and use Kùzu Explorer to visualize the resulting RDF graph.
+We will demonstrate how to load this data into Kuzu, write SHACL shape constraints to validate the data,
+and use Kuzu Explorer to visualize the resulting RDF graph.
 
 ## Basics of RDF
 
-Our [earlier blog post](../in-praise-of-rdf) on RDF and Kùzu's [docs](https://docs.kuzudb.com/rdf-graphs/rdf-basics/)
+Our [earlier blog post](../in-praise-of-rdf) on RDF and Kuzu's [docs](https://docs.kuzudb.com/rdf-graphs/rdf-basics/)
 provide a much more detailed explanation on RDF and when it is useful, but for the purposes
 of this post, a brief summary of the terminology is provided in the table below:
 
@@ -55,13 +55,13 @@ The following is an excerpt from the [SHACL specification](https://www.w3.org/TR
 
 > The Shapes Constraint Language (SHACL) is a language for validating RDF graphs against a set of conditions. These conditions are provided as shapes and other constructs expressed in the form of an RDF graph. RDF graphs that are used in this manner are called "shapes graphs" in SHACL and the RDF graphs that are validated against a shapes graph are called "data graphs". As SHACL shape graphs are used to validate that data graphs satisfy a set of conditions they can also be viewed as a description of the data graphs that do satisfy these conditions.
 
-Although the purpose of this post is to demonstrate how SHACL can be used to validate RDF data in Kùzu, SHACL also allows for a variety of other use cases
+Although the purpose of this post is to demonstrate how SHACL can be used to validate RDF data in Kuzu, SHACL also allows for a variety of other use cases
 besides validation, such as user interface building and data integration[^4].
 
 ## Example
 
-This section will walk you through a demonstration of how to load RDF data into Kùzu, validate it against SHACL shapes,
-and visualize the RDF graph using Kùzu Explorer.
+This section will walk you through a demonstration of how to load RDF data into Kuzu, validate it against SHACL shapes,
+and visualize the RDF graph using Kuzu Explorer.
 
 ### Dataset
 
@@ -105,11 +105,11 @@ Pictorially, this can be represented in RDF as follows:
 `kz:Adam` is an alias for the IRI `http://kuzu.io/rdf-ex#Adam`, as specified in the prefix section at the top of the Turtle file. Each resource's properties are
 represented as triples between the resource and literals. The relationships between resources are also represented as triples, such as `kz:Adam livesIn kz:Waterloo`.
 
-### Load data into a Kùzu database
+### Load data into a Kuzu database
 
-The following snippet shows how to ingest the RDF data into Kùzu. We first create an RDF graph
+The following snippet shows how to ingest the RDF data into Kuzu. We first create an RDF graph
 and then copy data from the Turtle file named `uni.ttl` into a local database directory named `db`.
-We can specify the name of the RDF database in Kùzu as a constant, `UniKG`, so that it can be used
+We can specify the name of the RDF database in Kuzu as a constant, `UniKG`, so that it can be used
 in the downstream Cypher queries.
 
 ```python
@@ -120,7 +120,7 @@ DB_PATH = "db"
 DB_NAME = "UniKG"
 db_path = pathlib.Path(DB_PATH)
 
-# Populate Kùzu with the RDF data
+# Populate Kuzu with the RDF data
 db = kuzu.Database(DB_PATH)
 conn = kuzu.Connection(db)
 
@@ -128,16 +128,16 @@ conn.execute(f"CREATE RDFGraph {DB_NAME}")
 conn.execute(f"COPY {DB_NAME} FROM 'uni.ttl'")
 ```
 
-### Register Kùzu in RDFLib plugins
+### Register Kuzu in RDFLib plugins
 
 [RDFLib](https://rdflib.readthedocs.io/en/stable/) is a well-known Python library that provides an API for querying RDF data,
 allowing Python developers access to the entire W3C stack. It is extensible with plugins[^2], allowing
 it to work with different storage backends. For this blog post,
-we published an unofficial code repo that showcases how to use RDFLib with Kùzu as a backend.
+we published an unofficial code repo that showcases how to use RDFLib with Kuzu as a backend.
 The code can be found [here](https://github.com/DerwenAI/kuzu-rdflib).
 
-To begin, we simply register the Kùzu plugin in RDFLib, instantiate an RDFLib `Graph` object that uses
-Kùzu as the backend, and open the graph. To allow the user to specify which Kùzu database to use,
+To begin, we simply register the Kuzu plugin in RDFLib, instantiate an RDFLib `Graph` object that uses
+Kuzu as the backend, and open the graph. To allow the user to specify which Kuzu database to use,
 we pass the configuration data containing the database name and directory path as a mapping to the `open` method.
 
 ```python
@@ -172,12 +172,12 @@ graph.open(
 ```
 
 Note that there needs to be a 1:1 correspondence between the instantiated `Graph`​ object in RDFlib
-and a named KùzuDB database (in this case, `UniKg`). If you're creating a new RDF database in Kùzu, you
+and a named KùzuDB database (in this case, `UniKg`). If you're creating a new RDF database in Kuzu, you
 would need to reference that name instead in the `config_data` mapping for the RDFLib plugin.
 
 Under the hood, a custom method called `get_graph()`​
 is defined in [our demo code](https://github.com/DerwenAI/kuzu-rdflib/blob/main/graph.py) which
-allows for direct access to the underlying Kùzu RDF graph. We encourage you to explore the code
+allows for direct access to the underlying Kuzu RDF graph. We encourage you to explore the code
 in more detail and try the above workflow on your own data to understand how it works.
 
 We can then interact with our graph in RDFLib by running a simple SPARQL query that retrieves all
@@ -223,7 +223,7 @@ RDFLib comes with an implementation of the SPARQL 1.1 query language[^5], so you
 complex queries with additional predicate filters, including prepared queries that can save
 time in re-parsing and translating the query into SPARQL algebra each time the query is run[^5].
 
-This means that you can actually query your Kùzu RDF graphs with SPARQL instead of Cypher using the Kuzu-RDFLib extension!
+This means that you can actually query your Kuzu RDF graphs with SPARQL instead of Cypher using the Kuzu-RDFLib extension!
 See the [section below](#query-the-rdf-graph-with-cypher) for an additional example.
 
 ### Specify SHACL shape constraints
@@ -304,11 +304,11 @@ To learn more about using SHACL in general, see the
 [SHACL Wiki](https://kvistgaard.github.io/shacl/#/page/shacl%20wiki) project by
 Veronika Heimsbakk and Ivo Velitchkov.
 
-### Visualize the RDF graph in Kùzu Explorer
+### Visualize the RDF graph in Kuzu Explorer
 
-When building and validating RDF graphs, the ability to get visual feedback is quite useful. Kùzu
+When building and validating RDF graphs, the ability to get visual feedback is quite useful. Kuzu
 Explorer is a web-based interface that allows you to visualize RDF graphs and query them using Cypher (no knowledge of SPARQL required).
-The instructions to launch Kùzu Explorer and connect to an existing database are shown in [the docs](https://docs.kuzudb.com/visualization/).
+The instructions to launch Kuzu Explorer and connect to an existing database are shown in [the docs](https://docs.kuzudb.com/visualization/).
 
 ```bash
 docker run -p 8000:8000 \
@@ -316,7 +316,7 @@ docker run -p 8000:8000 \
     --rm kuzudb/explorer:latest
 ```
 
-In a nutshell, Kùzu's [RDFGraphs extension](https://docs.kuzudb.com/rdf-graphs/) creates four distinct tables when the RDF data is loaded into the database:
+In a nutshell, Kuzu's [RDFGraphs extension](https://docs.kuzudb.com/rdf-graphs/) creates four distinct tables when the RDF data is loaded into the database:
 
 - `UniKG_l`: A node table that contains literals
 - `UniKG_r`: A node table that contains resources, where the primary key is the unique IRI
@@ -336,17 +336,17 @@ As can be seen, the graph structure is identical to that shown earlier, in the p
 
 The yellow edges represent resource-to-literal relationships (`UniKG_lt`), while the red edges represent
 resource-to-resource relationships (`UniKG_rt`). We can inspect the schema of the RDF graph, including
-each table's primary keys, visually, by clicking on the "Schema" tab in Kùzu Explorer.
+each table's primary keys, visually, by clicking on the "Schema" tab in Kuzu Explorer.
 
 ![](/img/rdf-shacl-kuzu/demo-rdf-schema.png)
 
 ### Query the RDF graph with Cypher
 
-Recall that earlier, we showed how to query the RDF database using SPARQL in RDFLib. However, Kùzu also supports
+Recall that earlier, we showed how to query the RDF database using SPARQL in RDFLib. However, Kuzu also supports
 querying RDF graphs using Cypher! In the example below, we run a query to only return students named "Karissa".
 
 ```cypher
-// Run using Kùzu Explorer
+// Run using Kuzu Explorer
 WITH "http://kuzu.io/rdf-ex#" as kz
 MATCH (s {iri: kz + "Karissa"})-[p1 {iri: kz + "name"}]->(l)
 WHERE (s)-[p2]->(o {iri: kz + "student"})
@@ -376,45 +376,45 @@ http://kuzu.io/rdf-ex#Karissa   http://kuzu.io/rdf-ex#name      Karissa
 ```
 
 As can be seen, **you can choose the most appropriate query language** to analyze your data, depending on your
-workflow and how you want to interface with the graph -- using SPARQL via RDFLib or Cypher via Kùzu.
-Under the hood, Kùzu's query processor will use its native structured property
+workflow and how you want to interface with the graph -- using SPARQL via RDFLib or Cypher via Kuzu.
+Under the hood, Kuzu's query processor will use its native structured property
 graph model to plan and optimize the query, so there are no negative performance implications when using Cypher.
 
 You can also extend Kuzu's RDFGraphs with other property graphs, and query both your triples
-*and* the other property graphs with a uniform query language, Cypher. See Kùzu's [documentation](https://docs.kuzudb.com/rdf-graphs/rdfgraphs-overview#querying-of-regular-node-and-relationship-tables-and-rdfgraphs) page for more information.
+*and* the other property graphs with a uniform query language, Cypher. See Kuzu's [documentation](https://docs.kuzudb.com/rdf-graphs/rdfgraphs-overview#querying-of-regular-node-and-relationship-tables-and-rdfgraphs) page for more information.
 
 ---
 
 ### Note on performance
-When running SPARQL queries via RDFLib on top of a Kùzu backend, keep in mind that all the
+When running SPARQL queries via RDFLib on top of a Kuzu backend, keep in mind that all the
 RDF triples are pulled into memory, so this may not work well for larger graphs where the triples
 do not fit in memory. However, in such cases, you could still query the RDF graph directly in Cypher
-via Kùzu's [RDFGraphs](https://docs.kuzudb.com/rdf-graphs/rdfgraphs-overview/)
+via Kuzu's [RDFGraphs](https://docs.kuzudb.com/rdf-graphs/rdfgraphs-overview/)
 while also retaining query performance.
 
 ---
 
 ## Conclusions
 
-In this post, we showed how RDF data in Turtle format can be easily loaded into Kùzu using RDFLib. This was
-done by specifying Kùzu as a backend in the RDFLib plugin. We then demonstrated how SHACL shapes can be used to
+In this post, we showed how RDF data in Turtle format can be easily loaded into Kuzu using RDFLib. This was
+done by specifying Kuzu as a backend in the RDFLib plugin. We then demonstrated how SHACL shapes can be used to
 validate the RDF data via the pySHACL library, allowing users to create data graphs in RDF that satisfy a set of conditions.
-We also showed how Kùzu provides a simple and intuitive interface to load, query and visualize RDF graphs, without compromising
-scalability and performance, because the RDF triples are essentially mapped to Kùzu's native property graph model.
-Users can decide whether to query the graph via SPARQL (via RDFLib) or via Cypher (directly in Kùzu).
+We also showed how Kuzu provides a simple and intuitive interface to load, query and visualize RDF graphs, without compromising
+scalability and performance, because the RDF triples are essentially mapped to Kuzu's native property graph model.
+Users can decide whether to query the graph via SPARQL (via RDFLib) or via Cypher (directly in Kuzu).
 
 This is just the tip of the iceberg in terms of the pipelines you can build over
-your Kùzu RDFGraphs with RDFLib integration. This post showed only how you get access to
+your Kuzu RDFGraphs with RDFLib integration. This post showed only how you get access to
 two implementations of RDF standards in Python: SPARQL and SHACL. But there are other Python
 libraries that integrate with RDFLib to implement other standards, such as [OWL](https://www.w3.org/OWL/) through the Python [OWL-RL](https://owl-rl.readthedocs.io/en/latest/)
 library. OWL-RL can be used to do basic inheritance computations. 
-Using the Kùzu plugin for RDFLib (see [here](https://github.com/DerwenAI/kuzu-rdflib)) in conjunction with these libraries,
+Using the Kuzu plugin for RDFLib (see [here](https://github.com/DerwenAI/kuzu-rdflib)) in conjunction with these libraries,
 you can build more complex pipelines and get access to the implementations of other RDF standards.
 Check out the examples in Derwen.ai's [kglab](https://github.com/DerwenAI/kglab) library to see a variety of
 other RDFLib plugins you get access to in Python.
 
 We hope this post has provided a good starting point for you to explore RDF data models, SHACL, and how
-to combine them using Kùzu as your graph backend. Feel free to go through our RDFGraphs [documentation](https://docs.kuzudb.com/rdf-graphs/)
+to combine them using Kuzu as your graph backend. Feel free to go through our RDFGraphs [documentation](https://docs.kuzudb.com/rdf-graphs/)
 to learn more!
 
 ## Code

--- a/src/content/post/2024-07-31-kuzu-v-0.5.0.md
+++ b/src/content/post/2024-07-31-kuzu-v-0.5.0.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.5.0-release"
-title: "Kùzu 0.5.0 Release"
-description: "Release announcement for Kùzu 0.5.0"
+title: "Kuzu 0.5.0 Release"
+description: "Release announcement for Kuzu 0.5.0"
 pubDate: "July 31 2024"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -9,17 +9,17 @@ authors: ["team"]
 tags: ["cypher", "extensions"]
 ---
 
-It's been a very productive summer for all of us at Kùzu Inc., and we are excited to announce the release of Kùzu **0.5.0**! In this (rather long) blog post, we will break down a significant list of updates that were made to Kùzu's core in the last few months, including performance improvements. These include MVCC-based faster transactions, as well as several new features, such as attaching to remote Kùzu and SQLite databases, Python UDFs, scanning and outputting to JSON, scanning and loading from Polars DataFrames, and for a bonus usability feature, a progress bar in CLI and Kùzu Explorer! Without any further ado, let's dive in.
+It's been a very productive summer for all of us at Kùzu Inc., and we are excited to announce the release of Kuzu **0.5.0**! In this (rather long) blog post, we will break down a significant list of updates that were made to Kuzu's core in the last few months, including performance improvements. These include MVCC-based faster transactions, as well as several new features, such as attaching to remote Kuzu and SQLite databases, Python UDFs, scanning and outputting to JSON, scanning and loading from Polars DataFrames, and for a bonus usability feature, a progress bar in CLI and Kuzu Explorer! Without any further ado, let's dive in.
 
 ## Performance improvements
 
-Performance has always been at the forefront of Kùzu's design, and this release is no exception. We've made
+Performance has always been at the forefront of Kuzu's design, and this release is no exception. We've made
 several improvements to the core storage and query engine to make it faster and more efficient. Below, we list two
 of these updates, starting with multi-version concurrency control-based (MVCC) transaction management.
 
 ### MVCC-based transaction manager
 
-In prior releases, Kùzu imposed certain limitations on transactions. 
+In prior releases, Kuzu imposed certain limitations on transactions. 
 The biggest one was that we immediately checkpointed after each write transaction, 
 which could potentially block the entire system intermittently after each transaction. 
 In cases where users have to perform _many_ small write transactions, this could cause a lot more 
@@ -42,7 +42,7 @@ These changes have led to **significant** performance improvements in data inser
 CREATE NODE TABLE Person (id INT64, name STRING, age INT64, net_worth FLOAT, PRIMARY KEY (id));
 ```
 
-Each insertion itself is an auto-transaction, and queries are executed through a single Kùzu connection.
+Each insertion itself is an auto-transaction, and queries are executed through a single Kuzu connection.
 
 ```cypher
 // Pass each record's values as parameters as an individual transaction
@@ -52,28 +52,28 @@ CREATE (:Person {id: $id, name: $name, age: $age, net_worth: $net_worth})
 The timing numbers for the experiment below are from a Mac Mini Desktop with an Apple M2 Pro CPU and 32GB DRAM.
 We observed a **15x** speedup in version 0.5.0 in comparison to the previous version.
 
-| Kùzu Version  | Time (s) | Speedup factor |
+| Kuzu Version  | Time (s) | Speedup factor |
 | :-----------: | -------- |----------------|
 | 0.4.2         | 109.9    | --             |
 | 0.5.0         | 7.5      | 14.6           |
 
 The good news is that this is not the end of it! In our next phase of development, we will turn our attention
 towards fully supporting MVCC, with no limitations on concurrent read _and_ write transactions within a single process. Although at its core,
-Kùzu is designed to be very performant on read-heavy queries, moving to MVCC is also making Kùzu performant on
+Kuzu is designed to be very performant on read-heavy queries, moving to MVCC is also making Kuzu performant on
 transaction/write-heavy workloads!
 
 ### Remote file system cache
 
-Kùzu's [httpfs](https://docs.kuzudb.com/extensions/httpfs) extension allows scanning and copying from a remote file system (e.g., S3 or HTTPS).
-It also allows attaching to remote Kùzu databases, which is a new feature that's part of this release (see [below](#remote-kùzu-databases) for more on this).
+Kuzu's [httpfs](https://docs.kuzudb.com/extensions/httpfs) extension allows scanning and copying from a remote file system (e.g., S3 or HTTPS).
+It also allows attaching to remote Kuzu databases, which is a new feature that's part of this release (see [below](#remote-kùzu-databases) for more on this).
 However, the performance of `httpfs` scan operations can be slow because these are scans of remote files, especially if the 
 operations are on an object store, say S3.
 Therefore queries that involve operations on large files or many remote files can be slow.
 To enhance performance, we introduced a new option that enables local file caching for files hosted on remote file systems. 
-The local file cache is initialized when Kùzu sends the file a read request for the first time. 
+The local file cache is initialized when Kuzu sends the file a read request for the first time. 
 Subsequent remote file operations that are **within the same transaction** will then be translated as local file operations on the local file cache[^1].
 
-[^1]: Cached files are visible per transaction. If you run a `LOAD FROM` statement on a remote file, then this file will be downloaded first and then scanned locally from the downloaded file. If you run the same `LOAD FROM` statement again, it will be downloaded again from the remote URL. This is because the second statement is executed as a separate transaction and we do not know if the already downloaded remote file has changed since the last time Kùzu downloaded it. If you need to scan the same remote file multiple times and benefit from caching across multiple scans, you can run all the `LOAD FROM` statements in the same transaction. See the [docs](https://docs.kuzudb.com/extensions/httpfs#local-cache-for-remote-files) for more details.
+[^1]: Cached files are visible per transaction. If you run a `LOAD FROM` statement on a remote file, then this file will be downloaded first and then scanned locally from the downloaded file. If you run the same `LOAD FROM` statement again, it will be downloaded again from the remote URL. This is because the second statement is executed as a separate transaction and we do not know if the already downloaded remote file has changed since the last time Kuzu downloaded it. If you need to scan the same remote file multiple times and benefit from caching across multiple scans, you can run all the `LOAD FROM` statements in the same transaction. See the [docs](https://docs.kuzudb.com/extensions/httpfs#local-cache-for-remote-files) for more details.
 
 To illustrate the performance gains after enabling local file caching, here is a benchmark which scans an LDBC-10 `Comment` table
 which is 2.1GB in size and is stored on a remote S3 bucket.
@@ -83,7 +83,7 @@ The benchmark is run on a machine with 2x AMD EPYC 7551 servers.
 LOAD FROM 's3://kuzu-test/dataset/ldbc10/comment_0_0.csv'(HEADER=true, DELIM="|") RETURN *;
 -- 279.11ms (compiling), 1401724.86ms (execution), 1402003.97ms (total)
 ```
-In the above query, Kùzu makes multiple remote file requests to S3 to scan
+In the above query, Kuzu makes multiple remote file requests to S3 to scan
 the whole file remotely. This takes 1,402 sec. Below are the performance numbers when turning the `HTTP_CACHE_FILE` option on.
 
 ```sql
@@ -105,14 +105,14 @@ only 5.2 sec (an additional 6.3x gain) since it's completely executed on the loc
 
 This release also comes with a host of new features. Below, we list the main ones.
 
-### Remote Kùzu databases
+### Remote Kuzu databases
 
-Previously, Kùzu supported attaching to several remote relational DBMSs, e.g., Postgres and DuckDB.
-These RDBMS extensions support scanning and copying data from these databases into Kùzu. 
-In this release, we've extended this functionality to attach to remote Kùzu databases as well. However, instead of
+Previously, Kuzu supported attaching to several remote relational DBMSs, e.g., Postgres and DuckDB.
+These RDBMS extensions support scanning and copying data from these databases into Kuzu. 
+In this release, we've extended this functionality to attach to remote Kuzu databases as well. However, instead of
 just scanning the tuples in these databases, you can also run read-only Cypher queries on these databases. Here's a brief
-overview of how you can query external Kùzu databases. First,
-you install the `httpfs` extension and attach to a remote Kùzu database as follows:
+overview of how you can query external Kuzu databases. First,
+you install the `httpfs` extension and attach to a remote Kuzu database as follows:
 
 ```sql
 INSTALL httpfs;
@@ -120,8 +120,8 @@ LOAD EXTENSION httpfs;
 ATTACH 's3://kuzu-example/university' AS uw (dbtype kuzu);
 ```
 
-The above command attaches a remote Kùzu database located in an S3 bucket at `s3://kuzu-example/university`, and aliases it as `uw`.
-Now you can query this `uw` database in Cypher as if it's a local Kùzu database. That is, any Cypher query you run at this point,
+The above command attaches a remote Kuzu database located in an S3 bucket at `s3://kuzu-example/university`, and aliases it as `uw`.
+Now you can query this `uw` database in Cypher as if it's a local Kuzu database. That is, any Cypher query you run at this point,
 will be executed against the remote `uw` database. For example, if you type:
 
 ```cypher
@@ -129,21 +129,21 @@ MATCH (p:person) RETURN *
 ```
 
 This will scan the `person` node table in the `s3://kuzu-example/university` database. 
-To query your local Kùzu database again, you need to detach from the `uw` database (`DETACH uw`).
+To query your local Kuzu database again, you need to detach from the `uw` database (`DETACH uw`).
 
-One potential use case of this feature is to query your backups. That is, you can create backups of your local Kùzu databases 
+One potential use case of this feature is to query your backups. That is, you can create backups of your local Kuzu databases 
 remotely, say on S3, periodically. Then you can attach to any of these from the same script or a CLI and query them.
 You can use the [remote file system cache](https://docs.kuzudb.com/extensions/httpfs#local-cache-for-remote-files) feature
 (by running `HTTP_CACHE_FILE=true`),
-which we covered [above](#remote-file-system-cache), to cache these remote Kùzu databases to improve
+which we covered [above](#remote-file-system-cache), to cache these remote Kuzu databases to improve
 your query performance.
 
 See this [documentation page](https://docs.kuzudb.com/extensions/remote-kuzu)
-for more information on connecting to remote Kùzu databases.
+for more information on connecting to remote Kuzu databases.
 
 ### Python UDFs
 
-Earlier releases of Kùzu supported user-defined functions via the C++ API. In this release, we've extended
+Earlier releases of Kuzu supported user-defined functions via the C++ API. In this release, we've extended
 the UDF functionality to the benefit of Python users as well. To register a Python UDF, it's required to provide
 both a function signature and implementation. An example is shown below:
 
@@ -173,11 +173,11 @@ while result.has_next():
 ```
 
 In the above example, we define a function `difference` in Python that takes two integers and returns their difference.
-We then register this function with the Kùzu connection object `conn`, explicitly declaring the function's
+We then register this function with the Kuzu connection object `conn`, explicitly declaring the function's
 expected type signature. Finally, we use the function to perform the desired operation via a Cypher query.
 
-This can allow you to quickly extend Kùzu with new functions you need in your Python applications. However,
-before writing your own UDF, do check if an equivalent Cypher function in Kùzu exists, as native functions run faster
+This can allow you to quickly extend Kuzu with new functions you need in your Python applications. However,
+before writing your own UDF, do check if an equivalent Cypher function in Kuzu exists, as native functions run faster
 than UDFs.
 
 See this [documentation page](https://docs.kuzudb.com/client-apis/python#udf) for more information on Python UDFs.
@@ -243,9 +243,9 @@ information on these features.
 ### COPY FROM DataFrames
 
 `LOAD FROM` statements are used to scan external tuples and bind to variables 
-in Cypher queries. In contrast, `COPY FROM` statements are the fast way to do bulk data ingestion into Kùzu. Specifically,
-`COPY FROM` copies external data or results of subqueries into a Kùzu node or relationship table. 
-In prior releases of Kùzu, if you wanted to copy data from a Pandas DataFrame to a Kùzu table using `COPY FROM`, you
+in Cypher queries. In contrast, `COPY FROM` statements are the fast way to do bulk data ingestion into Kuzu. Specifically,
+`COPY FROM` copies external data or results of subqueries into a Kuzu node or relationship table. 
+In prior releases of Kuzu, if you wanted to copy data from a Pandas DataFrame to a Kuzu table using `COPY FROM`, you
 had to use a `LOAD FROM` subquery and pass that subquery to
 your `COPY FROM` statement. In the 0.5.0 release, we've
 made this far simpler by allowing you to directly `COPY FROM` a DataFrame.
@@ -268,13 +268,13 @@ Check out more details in this [documentation page](https://docs.kuzudb.com/impo
 ## New Extensions
 
 This release also introduces two new extensions (other than attaching to
-remote Kùzu databases, which we covered [above](#remote-kùzu-databases)): SQLite and JSON, whose key
+remote Kuzu databases, which we covered [above](#remote-kùzu-databases)): SQLite and JSON, whose key
 features are described below.
 
 ### SQLite scanner
 
 SQLite is one of the most widely deployed RDBMS systems, and we're pleased to announce our new SQLite
-scanner, allowing you to easily scan and copy your data from your SQLite databases into Kùzu without
+scanner, allowing you to easily scan and copy your data from your SQLite databases into Kuzu without
 having to export it to an intermediate format. To use this feature, first install and load the SQLite extension:
 
 ```sql
@@ -288,7 +288,7 @@ Attach a SQLite database by specifying the `dbtype` as `sqlite`:
 ATTACH 'university.db' AS uw (dbtype sqlite);
 ```
 
-Once the SQLite databases is attached, you can access its tables directly in Kùzu. The following
+Once the SQLite databases is attached, you can access its tables directly in Kuzu. The following
 command scans a table named `person` in the `uw` database that sits in SQLite.
 
 ```sql
@@ -298,8 +298,8 @@ Checkout more details in this [documentation page](https://docs.kuzudb.com/exten
 
 ### JSON support
 
-In this release, we've extended Kùzu to support scanning and ingesting data from JSON files, as well
-as writing data from Kùzu tables to JSON files. You can now scan a JSON file as follows:
+In this release, we've extended Kuzu to support scanning and ingesting data from JSON files, as well
+as writing data from Kuzu tables to JSON files. You can now scan a JSON file as follows:
 
 ```sql
 LOAD FROM 'data.json' RETURN *;
@@ -353,7 +353,7 @@ important ones.
 
 ### Create table if it does not exist
 
-In prior releases, Kùzu used to throw an exception when trying to create a table whose name already
+In prior releases, Kuzu used to throw an exception when trying to create a table whose name already
 exists in the database, which required custom error handling logic. This is no longer the case, as
 we now provide the `CREATE ... TABLE IF NOT EXISTS`
 syntax to avoid an exception being raised if the table already exists.
@@ -379,12 +379,12 @@ Note that you cannot drop a node table if there are relationship tables that dep
 above example, we made sure to drop the `Follows` table first before dropping the `Person` table.
 See this [documentation page](https://docs.kuzudb.com/cypher/data-definition/drop#if-exists) for further details.
 
-## Progress bar in CLI and Kùzu Explorer
+## Progress bar in CLI and Kuzu Explorer
 
 One frustrating issue in earlier versions was that during long-running queries, say a large bulk ingestion done in
 a `COPY FROM` statement, you would not get any feedback on how long the query would take.
 We now offer a progress bar that shows the percentage progress of a long-running query that's being
-executed. The progress bar is only available in the CLI and Kùzu Explorer, and you have to enable it prior to
+executed. The progress bar is only available in the CLI and Kuzu Explorer, and you have to enable it prior to
 executing the query, via the following command:
 
 ```sql
@@ -407,12 +407,12 @@ Numerous improvements were made to the C API for this release. We highlight thes
 
 ## Join order hints
 
-In certain cases, Kùzu could generate a sub-optimal join order when the obtained statistics are
+In certain cases, Kuzu could generate a sub-optimal join order when the obtained statistics are
 inaccurate at the optimization stage of a large graph query. Starting from this release, we provide
-the ability to specify join order hints to enforce a specific join strategy that bypasses Kùzu’s optimizer.
+the ability to specify join order hints to enforce a specific join strategy that bypasses Kuzu’s optimizer.
 In the coming months, we will be investing more time on our optimizer, but for now, this feature gives you a
 mechanism to explicitly control
-the join order Kùzu generates to improve the performances of your workloads.
+the join order Kuzu generates to improve the performances of your workloads.
 See the [details here](https://docs.kuzudb.com/developer-guide/join-order-hint).
 
 ## Closing Remarks
@@ -421,12 +421,12 @@ Whew, we just went over a lot of new features and improvements! But this blog po
 all that's been added in this release. For a comprehensive list, check out our [release notes](https://github.com/kuzudb/kuzu/releases/tag/v0.5.0)
 on GitHub.
 
-Our many thanks go out to the entire Kùzu team for their hard work in making this release possible. Hopefully,
+Our many thanks go out to the entire Kuzu team for their hard work in making this release possible. Hopefully,
 you find that these new features and improvements enhance your graph workflows and allow you to more easily
 bring your graph-based applications to production. In the coming months, we will continue to add more
-advanced functionalities to Kùzu, such as in-memory graphs and an inbuilt graph algorithms package within Kùzu.
+advanced functionalities to Kuzu, such as in-memory graphs and an inbuilt graph algorithms package within Kuzu.
 In the meantime, we recommend that you fire up a database using the newly released version and give these
 features a try! Do let us know if you have any feedback or questions on [Discord](https://discord.gg/VtX2gw9Rug),
-and have fun using Kùzu!
+and have fun using Kuzu!
 
 ---

--- a/src/content/post/2024-08-15-kuzu-v-0.6.0.md
+++ b/src/content/post/2024-08-15-kuzu-v-0.6.0.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.6.0-release"
-title: "Kùzu 0.6.0 Release"
-description: "Release announcement for Kùzu 0.6.0"
+title: "Kuzu 0.6.0 Release"
+description: "Release announcement for Kuzu 0.6.0"
 pubDate: "August 15 2024"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -9,19 +9,19 @@ authors: ["team"]
 tags: ["cypher"]
 ---
 
-It's been a short while since our last release, but we're back with a new version of Kùzu: 0.6.0!
-This release comes with several bug fixes, CLI updates and a much awaited feature: **in-memory mode** for Kùzu to quickly create temporary databases in memory.
+It's been a short while since our last release, but we're back with a new version of Kuzu: 0.6.0!
+This release comes with several bug fixes, CLI updates and a much awaited feature: **in-memory mode** for Kuzu to quickly create temporary databases in memory.
 Many users had asked for [this feature](https://github.com/kuzudb/kuzu/issues/1816), so we hope it simplifies and possibly speeds up some of your workloads.
 In this post, we'll give an overview of the in-memory feature and provide some insights about the performance benefits to expect
-when using this mode in Kùzu. We'll also highlight an improvement to the CLI that allows you to change the output mode of query results.
+when using this mode in Kuzu. We'll also highlight an improvement to the CLI that allows you to change the output mode of query results.
 
 ## In-memory mode
 
 ### Opening an in-memory database
 
-Kùzu now supports **both** "on-disk" and "in-memory" modes. 
+Kuzu now supports **both** "on-disk" and "in-memory" modes. 
 As you create your databases, if you do not specify a database path, specify an empty string, or
-explicitly specify`:memory:`, Kùzu will be opened under **in-memory** mode.
+explicitly specify`:memory:`, Kuzu will be opened under **in-memory** mode.
 
 Here's how to do this using the CLI (simply run the `kuzu` command in your terminal):
 
@@ -112,7 +112,7 @@ for more details on how to work with in-memory databases.
 The CLI now supports changing the output mode of query results via the `:mode [mode]` command. By
 default, the output mode is set to `box`, but you can change it to any one the modes listed below.
 To display all available output modes, simply type the `:mode` command without any arguments when
-you are in the Kùzu shell.
+you are in the Kuzu shell.
 
 ```
 kuzu> :mode
@@ -185,6 +185,6 @@ Read more details about this feature on the [documentation page](https://docs.ku
 ## Closing remarks
 
 The in-memory feature from this release is the first of many more usability and performance improvements
-in our upcoming roadmap for Kùzu. You can check the [release notes](https://github.com/kuzudb/kuzu/releases/tag/v0.6.0)
+in our upcoming roadmap for Kuzu. You can check the [release notes](https://github.com/kuzudb/kuzu/releases/tag/v0.6.0)
 on GitHub for a comprehensive list of the bugfixes and updates in this release. Once you give these
-features a try, come on over to our [Discord](https://kuzudb.com/chat) with your feedback. Till next time, have fun using Kùzu!
+features a try, come on over to our [Discord](https://kuzudb.com/chat) with your feedback. Till next time, have fun using Kuzu!

--- a/src/content/post/2024-11-13-kuzu-v-0.7.0.md
+++ b/src/content/post/2024-11-13-kuzu-v-0.7.0.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.7.0-release"
-title: "Kùzu 0.7.0 Release"
-description: "Release announcement for Kùzu 0.7.0"
+title: "Kuzu 0.7.0 Release"
+description: "Release announcement for Kuzu 0.7.0"
 pubDate: "November 15 2024"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -9,10 +9,10 @@ authors: ["team"]
 tags: ["cypher"]
 ---
 
-It's been a busy few months, and we are happy to announce the release of Kùzu 0.7.0!
+It's been a busy few months, and we are happy to announce the release of Kuzu 0.7.0!
 This release includes important performance and scalability improvements at the very
 core of the system along with some user-facing features. This blog post will highlight some key features that will
-make your experience with Kùzu even better when working with large graphs!
+make your experience with Kuzu even better when working with large graphs!
 
 ---
 
@@ -35,7 +35,7 @@ Among the user-facing features, we have the following additions:
  - **CSV auto detection** to automatically detect several CSV configurations during data ingest.
  - **Improved UX during CSV/JSON import** that can report to users about skipping erroneous CSV lines or JSON elements.
  - **New JSON data type** that you can use to store JSON blobs as node/relationship properties.
- - **New official Golang API** so that you can build applications on top of Kùzu using Go!
+ - **New official Golang API** so that you can build applications on top of Kuzu using Go!
 
 ---
 
@@ -81,9 +81,9 @@ All of the previous recursive path features are supported as before,
 e.g., using filters on intermediate nodes and relationships or the support for acyclic, trail, and walk semantics. 
 If you observe a slowdown, it's certainly a performance bug, so let us know and we will fix it!
 Oh, and all of the recursive computations happen by scanning data from disk, so we are not building any in-memory 
-index structures on the fly that can limit scalability. Kùzu's relationship/adjacency list storage is disk-based but already
+index structures on the fly that can limit scalability. Kuzu's relationship/adjacency list storage is disk-based but already
 optimized for good scan performance. So if your graphs are very large and don't need to fit into
-Kùzu's buffer manager, we will scale out of memory transparently. 
+Kuzu's buffer manager, we will scale out of memory transparently. 
 
 Below is a demonstrative micro-benchmark of the performance improvements on large databases.
 Let's take a query that finds the shortest path lengths from a single source to all other nodes. We use two input graphs:
@@ -95,7 +95,7 @@ In LDBC1000-PK, we use only the subgraph of Person nodes and Knows edges between
 448M nodes and 17B edges. When we load to disk, this graph takes 495GB on disk.
 
 All experiments we present in this post use a machine with 2 AMD EPYC 7551 processors (32 cores) and 512GB DDR4 memory and 2TB SSDs.
-We run Kùzu with its default settings.
+We run Kuzu with its default settings.
 
 In the next experiment, we find the length of shortest paths from a single source to all other nodes and count the
 number of nodes at each length. The query template looks as follows:
@@ -113,37 +113,37 @@ RETURN length(e), count(*);
 | 0.7.0 (Graph500-30) | 170.1s | 110.1s | 49.5s | 29s | 16.6s | 13.5s |
 
 On the 202M edge LDBC sub-graph, we compute shortest path lengths to all destinations in 0.32s using 32 threads. This is 
-a relatively small part of the entire LDBC database, and Kùzu does not scan much data from disk. 
+a relatively small part of the entire LDBC database, and Kuzu does not scan much data from disk. 
 
 On the 17B edge Graph500-30 graph, we compute shortest path lengths in **13.5s**. Note that we're finding shortest paths to 448M other nodes,
 and outputting 448M tuples from the recursive join operator,
 and this is happening on a completely disk-based implementation, so all scans happen through the 
 buffer manager. At this scale, there is actual I/O happening at each iteration of the shortest path computation and 
 the computation takes 16 iterations (so you can assume we're scanning large chunks of the 495GB database in many of the iterations).
-The previous version of Kùzu times out, which is set to 10 minutes, on this graph, while the new version can finish the query in 13.5 seconds using 32 threads.
+The previous version of Kuzu times out, which is set to 10 minutes, on this graph, while the new version can finish the query in 13.5 seconds using 32 threads.
 
-It's clear that both cases parallelize quite well and are much faster than the previous version of Kùzu. 
+It's clear that both cases parallelize quite well and are much faster than the previous version of Kuzu. 
 
 There are still more optimizations on our roadmap to make these even faster, so you can keep an eye on how these
 numbers are improving over upcoming releases.
 
 ### Data spilling during bulk relationship ingestion (COPY FROM)
-The recommended (fast) way to ingest large amounts of data into Kùzu is the [`COPY FROM`](https://docs.kuzudb.com/import/) statement.
+The recommended (fast) way to ingest large amounts of data into Kuzu is the [`COPY FROM`](https://docs.kuzudb.com/import/) statement.
 `COPY FROM` can be used to ingest records from a source into a node or relationship table.
 The source data can be in a local or remote file in some tabular format
 such as CSV, Parquet, or JSON, or in-memory objects, such as Pandas or Polars DataFrames, or the results of another subquery. 
 Prior to this release, `COPY FROM` had a scalability issue when ingesting billions of records into a relationship table.
-Specifically, Kùzu required storing all of the relationship records from the source *in memory* before it could start
+Specifically, Kuzu required storing all of the relationship records from the source *in memory* before it could start
 creating its persistent disk-based structures. This meant that if you had machines with relatively low RAM, you would have
 to manually chunk the source data into smaller parts, otherwise the `COPY FROM` pipeline could run out of memory and fail.
 
-In this release, Kùzu automatically spills the records it scans from the source table into
+In this release, Kuzu automatically spills the records it scans from the source table into
 a temporary file `.tmp` located inside the database directory on disk during `COPY FROM`. 
 The spilling is in fact done automatically by the buffer manager
 as `COPY FROM` demands more and more memory.
-It is by default turned on when you open a local Kùzu database under read-write mode, and you can choose to turn if off by `CALL spill_to_disk=false;`.
+It is by default turned on when you open a local Kuzu database under read-write mode, and you can choose to turn if off by `CALL spill_to_disk=false;`.
 Note that we don't support spilling under in-memory mode for now.
-As a result of this improvement, Kùzu can now ingest very
+As a result of this improvement, Kuzu can now ingest very
 large sets of relationship records (such as the edges of the 17B Graph500-30 graph in the above experiment) 
 when it is running on a machine with limited memory.
 
@@ -178,7 +178,7 @@ WHERE a.age < 10
 RETURN *
 ```
 
-To evaluate this query, Kùzu needs to scan the `age` column
+To evaluate this query, Kuzu needs to scan the `age` column
 of a the `Person` node table. If for a particular node group `j`, the minimum value stored for the zone map is greater than 10, say 15,
 then the system can skip over scanning the entire node group, since no value in node group `j` can pass the filter.
 
@@ -229,9 +229,9 @@ As with zone maps, this optimization also does not require any manual configurat
 #### Filter/projection push down to attached relational databases
 
 This performance optimization is related to
-attaching to external DuckDB, Postgres, and SQLite databases using Kùzu's [external RDBMSs extension](https://docs.kuzudb.com/extensions/attach/rdbms/).
+attaching to external DuckDB, Postgres, and SQLite databases using Kuzu's [external RDBMSs extension](https://docs.kuzudb.com/extensions/attach/rdbms/).
 Suppose you have attached to a remote Postgres database `uw` that has a `Person` table and you would like to copy the records
-in this table to a `Person` node table in Kùzu. You can run the following query:
+in this table to a `Person` node table in Kuzu. You can run the following query:
 
 ```cypher
 COPY Person FROM (
@@ -243,7 +243,7 @@ COPY Person FROM (
 
 The `age > 10` predicate in the above query is part of the `LOAD FROM` and filters the tuples in the Postgres table based on
 their `age` values. Part of the query's execution requires sending a SQL statement to Postgres to scan the `uw.Person` records.
-Previously, Kùzu would scan all tuples in `uw.Person` using a simple `SELECT * FROM uw.person` query
+Previously, Kuzu would scan all tuples in `uw.Person` using a simple `SELECT * FROM uw.person` query
 and run any filters and projections in its own query processor.
 Starting from this release, we now push down filters in the `WHERE` clause to the SQL query sent to Postgres.
 The same happens for projections, i.e., when possible, projections are also pushed to SQL queries sent to the external RDBMSs.
@@ -252,7 +252,7 @@ The same happens for projections, i.e., when possible, projections are also push
 
 ### JSON data type
 If you work with JSON data, you'll find that this latest release has a new data type: `JSON`.
-In Kùzu's previous versions, you could scan and load data from JSON files but you could not have node or relationship
+In Kuzu's previous versions, you could scan and load data from JSON files but you could not have node or relationship
 properties that are of type `JSON`.
 To use this data type, you need to install the [JSON extension](https://docs.kuzudb.com/extensions/json/).
 Along with this data type, we also provide a set of [functions](https://dev-docs.kuzudb.com/extensions/json/#json-functions)
@@ -302,14 +302,14 @@ for using [`LOAD FROM`](https://docs.kuzudb.com/cypher/query-clauses/load-from#i
 ### CSV auto detection
 
 To make it easier for users to work with data in CSV format, we implemented our own CSV sniffer.
-Kùzu can now automatically detect several CSV configurations, such as delimiter, quote, and escape character,
+Kuzu can now automatically detect several CSV configurations, such as delimiter, quote, and escape character,
 and apply them when using them with `COPY/LOAD FROM` statements. See our [docs](https://docs.kuzudb.com/import/csv/) for some
 examples on how CSV auto detection works.
 
 
 ### Attach remote DuckDB
 
-Earlier releases allowed attaching Kùzu to local DuckDB databases. This release extends the functionality to also allow attaching to
+Earlier releases allowed attaching Kuzu to local DuckDB databases. This release extends the functionality to also allow attaching to
 remote DuckDB databases on S3. The syntax looks something like this:
 
 ```cypher
@@ -318,33 +318,33 @@ ATTACH 's3://my_s3_url/my_bucket/persons.duckdb' as person_db (dbtype duckdb);
 LOAD FROM person_db.persons RETURN COUNT(*);
 ```
 
-All you need to do is point to the S3 URL that contains a remote DuckDB database and Kùzu can then
+All you need to do is point to the S3 URL that contains a remote DuckDB database and Kuzu can then
 scan and load data from it. See the external RDBMS [docs](https://docs.kuzudb.com/extensions/attach/rdbms/) for more details.
 
 ## Golang API
 
 A lot of of our users work with Golang and [have been requesting](https://github.com/kuzudb/kuzu/issues/2003)
-official support for it in Kùzu, so we are pleased to announce our new Golang client API in this release!
+official support for it in Kuzu, so we are pleased to announce our new Golang client API in this release!
 The Go package is a wrapper around our C API, so it shares the same performance and scalability characteristics.
 If your primary application language is Go, please give this a go (pun intended 😄). You can check out the documentation
 for the Golang API [here](https://pkg.go.dev/github.com/kuzudb/go-kuzu).
 
 ## (Temporary) Removal of RDFGraphs
 
-After much deliberation, we have removed our RDFGraphs feature from Kùzu beginning from this release.
-We had originally added this feature to enable users to import and query their raw RDF data, for e.g., a Turtle file, in Kùzu,
+After much deliberation, we have removed our RDFGraphs feature from Kuzu beginning from this release.
+We had originally added this feature to enable users to import and query their raw RDF data, for e.g., a Turtle file, in Kuzu,
 so they can do basic querying over their RDF triples using Cypher (similar to Neosemantics).
 However, we had designed this as a core extension of our data model. Over time, we realized this was too aggressive 
 and maintaining this as a core feature was slowing the overall development.
 So we decided to remove it from the core system. We are discussing instead to repackage it as an extension and release it at some later date. Some
 discussion around this decision can be found [here](https://github.com/kuzudb/kuzu/issues/4289). Users
-who are interested in using RDFGraphs can continue using version 0.6.1 of Kùzu. If you'd like to
+who are interested in using RDFGraphs can continue using version 0.6.1 of Kuzu. If you'd like to
 discuss your RDF use cases further, please join us on [Discord](https://kuzudb.com/chat)
 and create a discussion issue on the #discussion channel to start a conversation.
 
 ## Closing remarks
 
-Version 0.7.0 furthers Kùzu's larger vision of enabling users to build faster and more scalable graph-based applications,
+Version 0.7.0 furthers Kuzu's larger vision of enabling users to build faster and more scalable graph-based applications,
 and we couldn't be more excited to see what you build with it! Please give this release a try
 and chat with us and other users on [Discord](https://discord.gg/VtX2gw9Rug) if you have any questions.
 As always, you can check out the [release notes](https://github.com/kuzudb/kuzu/releases/tag/v0.7.0)

--- a/src/content/post/2024-11-18-how-bauplan-leverages-kuzu.md
+++ b/src/content/post/2024-11-18-how-bauplan-leverages-kuzu.md
@@ -1,7 +1,7 @@
 ---
 slug: "how-bauplan-leverages-kuzu"
-title: "Ephemeral graphs for data DAGs: How Bauplan leverages Kùzu for FaaS planning"
-description: "Discover how Bauplan innovated on their FaaS planning pipelines using in-memory graphs in Kùzu, achieving 20x faster planning performance and more debuggable, maintainable workflows."
+title: "Ephemeral graphs for data DAGs: How Bauplan leverages Kuzu for FaaS planning"
+description: "Discover how Bauplan innovated on their FaaS planning pipelines using in-memory graphs in Kuzu, achieving 20x faster planning performance and more debuggable, maintainable workflows."
 pubDate: "November 20 2024"
 heroImage: "/img/how-bauplan-leverages-kuzu/bauplan-control-plane.png"
 categories: ["example"]
@@ -57,11 +57,11 @@ The declarative API creates a principled division of labor between the system (i
 
 ## The challenge: From specifications to execution
 
-Unlike most FaaS platforms, Bauplan has a Control Plane (CP) / Data Plane (DP) separation: user code is shipped to the CP, which parses the code and produces a plan (using Kùzu) -- the plan is then sent to secure cloud workers in the DP for the actual execution. The below figure shows a simplified version of the CP. For a deeper architectural dive, check out the [Middleware paper](https://arxiv.org/pdf/2410.17465). Note that the CP never sees any actual data, it just sees the metadata.
+Unlike most FaaS platforms, Bauplan has a Control Plane (CP) / Data Plane (DP) separation: user code is shipped to the CP, which parses the code and produces a plan (using Kuzu) -- the plan is then sent to secure cloud workers in the DP for the actual execution. The below figure shows a simplified version of the CP. For a deeper architectural dive, check out the [Middleware paper](https://arxiv.org/pdf/2410.17465). Note that the CP never sees any actual data, it just sees the metadata.
 
 <Image src="/img/how-bauplan-leverages-kuzu/bauplan-control-plane.png" />
 
-<center><i>Overview of Bauplan’s Control Plane. A logical plan is created by parsing the user’s code. The physical plan is obtained by planning with Kùzu (e.g., adding system tasks, running validation rules). A third and lower layer omitted from the figure includes sending the physical plan to workers to execute in the cloud.</i></center>
+<center><i>Overview of Bauplan’s Control Plane. A logical plan is created by parsing the user’s code. The physical plan is obtained by planning with Kuzu (e.g., adding system tasks, running validation rules). A third and lower layer omitted from the figure includes sending the physical plan to workers to execute in the cloud.</i></center>
 
 The system’s goal is to go from declarative code to validated instructions for the workers: for example the `cleaned_data` input should be transformed from this implicit dependency:
 
@@ -132,14 +132,14 @@ The key insight we had is that FaaS planning with data DAGs boils down to graph 
 
 As every Bauplan run is an isolated end-to-end execution, planning graphs need to be instantiated only for the span of our checks - not dissimilar from our [approach to OLAP](https://towardsdatascience.com/a-serverless-query-engine-from-spare-parts-bd6320f10353), our ideal tool would allow ephemeral, in-memory graphs to be built, queried, and destroyed quickly. In other words, our graphs are “stateless” and exist only when processing a user request.
 
-For these reasons, we needed a database that implements Cypher or a Cypher-like language and [Kùzu](https://github.com/kuzudb/kuzu) was a perfect match for several reasons:
+For these reasons, we needed a database that implements Cypher or a Cypher-like language and [Kuzu](https://github.com/kuzudb/kuzu) was a perfect match for several reasons:
 
-- Kùzu is an **in-process (embeddable) database**, i.e., it is a library, so the database runs as part of our control plane code. This means we don’t have to maintain a separate graph database server, which simplifies development as well as deployment.
-- Kùzu is **very fast**: Kùzu can ingest and query data very quickly and also parallelizes queries well on multi-core machines. We were already able to use it when it did not support ephemeral in-memory databases, but since v0.6.0, they also have an in-memory mode, which made it even faster for our use case. See below for some concrete numbers on this point.
+- Kuzu is an **in-process (embeddable) database**, i.e., it is a library, so the database runs as part of our control plane code. This means we don’t have to maintain a separate graph database server, which simplifies development as well as deployment.
+- Kuzu is **very fast**: Kuzu can ingest and query data very quickly and also parallelizes queries well on multi-core machines. We were already able to use it when it did not support ephemeral in-memory databases, but since v0.6.0, they also have an in-memory mode, which made it even faster for our use case. See below for some concrete numbers on this point.
 
 In short, we were able to benefit from using Cypher to express our rules declaratively and could benefit from a fast and simple to use database without the complications of setting up and maintaining a separate database server.
 
-Re-written the Kùzu way, the imperative rules from above would look like the following. The code below assumes that we have created and populated a database with `Tbl(id SERIAL, name STRING, cols STRING[])` nodes and `Parent(FROM Tbl to Tbl)` relationships:
+Re-written the Kuzu way, the imperative rules from above would look like the following. The code below assumes that we have created and populated a database with `Tbl(id SERIAL, name STRING, cols STRING[])` nodes and `Parent(FROM Tbl to Tbl)` relationships:
 
 ```py
 import kuzu
@@ -171,16 +171,16 @@ res = conn.execute(
 # Some code to error if the answer is not empty.
 ```
 
-Leveraging Kùzu’s in-memory mode, creating a database with the relevant objects is a seamless operation; after its introduction, _our planning became **20x faster**_! To get a sense of the actual complexity of graph processing in Bauplan, real-world DAGs often involve ephemeral graphs in which more than 500 Cypher statements (between node and relationship creation, pattern matching, graph updates etc.) are executed by Kùzu in **~1.5 seconds**.
+Leveraging Kuzu’s in-memory mode, creating a database with the relevant objects is a seamless operation; after its introduction, _our planning became **20x faster**_! To get a sense of the actual complexity of graph processing in Bauplan, real-world DAGs often involve ephemeral graphs in which more than 500 Cypher statements (between node and relationship creation, pattern matching, graph updates etc.) are executed by Kuzu in **~1.5 seconds**.
 
 Once the graph is created, queries express validation rules as pattern matching over the graph. Note that the Cypher queries above for the rules are more explicit and express the rules at a higher level. While our developers now have to pay the price of learning enough Cypher to be dangerous, every additional check, transformation and validation can now be expressed uniformly in a high-performance framework: what if you want to track the *type lineage* of a column across nodes? Cypher query! What if you want to add user permissions for each table and guarantee that they are propagated properly to children? Cypher query ...
 
-There are other benefits of using Kùzu. On top of code simplification and standardization, we have built our own custom tools around the core graph engine: since our ephemeral graphs should be deterministically produced, at each Bauplan run, given the user code and a few environment variables, we built logging and debugging flows that allows us to precisely check our inference during development, and reproduce errors in live systems when debugging. In particular, we now maintain distinct table structures for different phases of plan generation, along with their relationships. This led us to develop what we call "certification process" -- a comprehensive suite that validates the graph at various stages of construction.
+There are other benefits of using Kuzu. On top of code simplification and standardization, we have built our own custom tools around the core graph engine: since our ephemeral graphs should be deterministically produced, at each Bauplan run, given the user code and a few environment variables, we built logging and debugging flows that allows us to precisely check our inference during development, and reproduce errors in live systems when debugging. In particular, we now maintain distinct table structures for different phases of plan generation, along with their relationships. This led us to develop what we call "certification process" -- a comprehensive suite that validates the graph at various stages of construction.
 
-The impact of this approach extends well beyond development and into our production environments. We've transformed our debugging capabilities by persisting both query logs and graph states to S3 during plan generation. Instead of reproducing issues by reconstructing the entire service context locally, we can now analyze production anomalies asynchronously by downloading the query log, rebuilding the exact graph generated at request time, and inspecting it programmatically and visually through [Kùzu Explorer](https://docs.kuzudb.com/visualization/). This clear separation between plan generation logic and service code has significantly streamlined our debugging workflow, allowing us to diagnose issues with precision and efficiency.
+The impact of this approach extends well beyond development and into our production environments. We've transformed our debugging capabilities by persisting both query logs and graph states to S3 during plan generation. Instead of reproducing issues by reconstructing the entire service context locally, we can now analyze production anomalies asynchronously by downloading the query log, rebuilding the exact graph generated at request time, and inspecting it programmatically and visually through [Kuzu Explorer](https://docs.kuzudb.com/visualization/). This clear separation between plan generation logic and service code has significantly streamlined our debugging workflow, allowing us to diagnose issues with precision and efficiency.
 
 ## What’s next? See you, graph cowboys!
 
-We have been using Kùzu for over a year now in production and are actively extending our usage. While Kùzu in-memory graphs are already an important part of our CP (using Python), we envision a near future in which we expand its use to the DP as well (using Kùzu's [Golang API)](https://pkg.go.dev/github.com/kuzudb/go-kuzu)): the possibility of sharing the same data structures and inferences across different components is an exciting development for our distributed architecture.
+We have been using Kuzu for over a year now in production and are actively extending our usage. While Kuzu in-memory graphs are already an important part of our CP (using Python), we envision a near future in which we expand its use to the DP as well (using Kuzu's [Golang API)](https://pkg.go.dev/github.com/kuzudb/go-kuzu)): the possibility of sharing the same data structures and inferences across different components is an exciting development for our distributed architecture.
 
 Want to know more about Bauplan? Read [our blog](https://www.bauplanlabs.com/blog), check out our [latest papers](https://arxiv.org/pdf/2404.13682), or just [join our private beta](https://www.bauplanlabs.com/#join) to try it out!

--- a/src/content/post/2025-02-05-kuzu-v-0.8.0.md
+++ b/src/content/post/2025-02-05-kuzu-v-0.8.0.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.8.0-release"
-title: "Kùzu 0.8.0 Release"
-description: "Release announcement for Kùzu 0.8.0"
+title: "Kuzu 0.8.0 Release"
+description: "Release announcement for Kuzu 0.8.0"
 pubDate: "Feb 05 2025"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -9,8 +9,8 @@ authors: ["team"]
 tags: ["cypher"]
 ---
 
-It's 2025, and we're kicking off the year with the exciting release of Kùzu 0.8.0. This release brings a new feature that distinguishes Kùzu from any other graph database out there -- Kùzu-WASM for in-browser graph analytics. You can now run your graph database while keeping all data and compute within your browser session! 
-Our extension ecosystem also has an exciting addition: `fts` extension for full-text search. You can now run keyword-based search queries using BM25 in Kùzu.
+It's 2025, and we're kicking off the year with the exciting release of Kuzu 0.8.0. This release brings a new feature that distinguishes Kuzu from any other graph database out there -- Kuzu-WASM for in-browser graph analytics. You can now run your graph database while keeping all data and compute within your browser session! 
+Our extension ecosystem also has an exciting addition: `fts` extension for full-text search. You can now run keyword-based search queries using BM25 in Kuzu.
 
 In addition to these new features, we’ve streamlined the developer workflow during relationship table creation by unifying `CREATE REL TABLE GROUP` into a single, flexible `CREATE REL TABLE` syntax. 
 
@@ -19,40 +19,40 @@ In the following sections, we dive into details.
 
 ## New Features
 
-### Kùzu-WASM
-Starting from version 0.8.0, we are happy to release a [WebAssembly](https://webassembly.org/) (WASM) version of Kùzu that runs within web browsers on a variety of devices.
+### Kuzu-WASM
+Starting from version 0.8.0, we are happy to release a [WebAssembly](https://webassembly.org/) (WASM) version of Kuzu that runs within web browsers on a variety of devices.
 
-Why is this exciting? With Kùzu-WASM, you can:
+Why is this exciting? With Kuzu-WASM, you can:
 - Perform interactive data analytics directly in the browser.
 - Achieve low latency with fast in-browser graph analytics.
 - Ensure data privacy if you need data to stay entirely in the browser.
 
 This makes it very useful for use cases like building interactive in-browser graph analytics and visualization
 in sensitive data environments, where users can analyze their data privately without transferring it to a server. 
-To use Kùzu-WASM, you have to install the `kuzu-wasm` package first:
+To use Kuzu-WASM, you have to install the `kuzu-wasm` package first:
 
 ```bash
 npm i kuzu-wasm
 ```
 
-Then, you can follow our [API documentation](https://docs.kuzudb.com/client-apis/wasm/) to integrate it into your projects. To see Kùzu-WASM in action,
-we have developed a WebAssembly version of Kùzu Explorer, which is Kùzu's browser-based graph visualization and CLI. You can check out this
+Then, you can follow our [API documentation](https://docs.kuzudb.com/client-apis/wasm/) to integrate it into your projects. To see Kuzu-WASM in action,
+we have developed a WebAssembly version of Kuzu Explorer, which is Kuzu's browser-based graph visualization and CLI. You can check out this
 demo [here](https://demo.kuzudb.com/).
 
 ### Full-Text Search (`fts`) Extension
 
-We're introducing an `fts` extension to enable full-text search capabilities using the [BM25](https://en.wikipedia.org/wiki/Okapi_BM25) scoring algorithm in Kùzu.
-The FTS index can be built on one or multiple columns in a Kùzu node table. Similar to other
+We're introducing an `fts` extension to enable full-text search capabilities using the [BM25](https://en.wikipedia.org/wiki/Okapi_BM25) scoring algorithm in Kuzu.
+The FTS index can be built on one or multiple columns in a Kuzu node table. Similar to other
 GDBMSs, we interpret each node as a "document".
 Our implementation of FTS is **native**, i.e., we do not use any separate libraries, similar to DuckDB's
 FTS feature, and is based on the paper [Old Dogs Are Great at New Tricks](https://www.duckdb.org/pdf/SIGIR2014-column-stores-ir-prototyping.pdf) (read the paper
 for a simple and elegant approach to support FTS natively in columnar systems!).
 
-In our implementation, we leveraged several graph-native capabilities of Kùzu: 
-words from source documents are stored as a Kùzu node table, while the occurrences 
-of words in "documents" are stored as a Kùzu relationship table. This means
+In our implementation, we leveraged several graph-native capabilities of Kuzu: 
+words from source documents are stored as a Kuzu node table, while the occurrences 
+of words in "documents" are stored as a Kuzu relationship table. This means
 our default CSR join index on relationship tables serves as an inverted index from words to documents,
-and allows Kùzu to answer queries very quickly (expect sub-second latencies).
+and allows Kuzu to answer queries very quickly (expect sub-second latencies).
 
 To utilize the FTS index, you have to first install and load the `fts` extension.
 ```sql
@@ -106,7 +106,7 @@ however generally have sub-second, ~0.5s, latencies.
 
 There are also some limitations for now -- FTS indices can only be built on node tables and are immutable.
 To refresh the index, you need to drop and recreate the index. We will work on removing these limitations in future releases.
-For more details on how to use FTS in Kùzu, you can check out our documentation [here](https://docs.kuzudb.com/extensions/full-text-search/). 
+For more details on how to use FTS in Kuzu, you can check out our documentation [here](https://docs.kuzudb.com/extensions/full-text-search/). 
 
 
 ## Usability Improvements
@@ -142,7 +142,7 @@ COPY IS_REPLY_OF FROM 'comment_isReplyOf_post.csv' (from='Comment', to='Post');
 
 Note that if the relationship table has only one source and destination node table, 
 you do not have to specify the source and target node table names. That is, the
-`COPY FROM` commands you used in the previous versions of Kùzu are still valid. You can
+`COPY FROM` commands you used in the previous versions of Kuzu are still valid. You can
 find more detailed documentation [here](https://docs.kuzudb.com/cypher/data-definition/create-table/#create-a-relationship-table).
 
 ### DataFrame usability improvements
@@ -153,7 +153,7 @@ In our [prior release](https://blog.kuzudb.com/post/kuzu-0.7.0-release/#allow-sk
 data into tables from CSV and Parquet files. We now extend this support to DataFrames. 
 Your `COPY FROM` commands from Pandas or Polars DataFrames can now be more robust to failure 
 due to incorrectly parsed column data types or other problems.
-When copying from a Pandas or Polars DataFrame into a Kùzu table, you can specify an `ignore_errors=true` 
+When copying from a Pandas or Polars DataFrame into a Kuzu table, you can specify an `ignore_errors=true` 
 parameter, allowing you to skip rows that might trigger an exception.
 
 ```sql
@@ -218,13 +218,13 @@ The new release (0.8.0) scales much better across multiple threads compared to 0
 
 ## Closing remarks
 
-We extend our thanks to the entire Kùzu team and our incredible
+We extend our thanks to the entire Kuzu team and our incredible
 interns who have worked very hard to make this release possible. We are thrilled to
-see Kùzu becoming a more and more feature-rich database, catering to a broader user base and a wide range of use cases.
+see Kuzu becoming a more and more feature-rich database, catering to a broader user base and a wide range of use cases.
 As usual, please share your experience with us – your feedback continues to
-shape Kùzu's evolution. From the sometimes unreasonable cold of 🇨🇦, where it was -23°C last week,
+shape Kuzu's evolution. From the sometimes unreasonable cold of 🇨🇦, where it was -23°C last week,
 we hope you enjoy the new release! 🎉 🎉
 
 Till next time!
 
-PS: Oh, and we promise, no tariffs to 🇺🇸; Kùzu is free and open-source!
+PS: Oh, and we promise, no tariffs to 🇺🇸; Kuzu is free and open-source!

--- a/src/content/post/2025-02-24-kuzu-v-0.8.2.md
+++ b/src/content/post/2025-02-24-kuzu-v-0.8.2.md
@@ -1,7 +1,7 @@
 ---
 slug: "kuzu-0.8.2-release"
-title: "Kùzu 0.8.2 Release"
-description: "Release announcement for Kùzu 0.8.2"
+title: "Kuzu 0.8.2 Release"
+description: "Release announcement for Kuzu 0.8.2"
 pubDate: "Feb 24 2025"
 heroImage: "/img/default.png"
 categories: ["release"]
@@ -23,7 +23,7 @@ In the following sections, we dive into details.
 ### Unity Catalog extension
 
 Unity Catalog, developed by Databricks, is an open data governance solution that allows you to manage your data catalogs, data access, and data sharing. It provides a unified interface for managing data across different data storage systems, including databases, data lakes, and data warehouses.
-For Kùzu users who are entrenched in the data lake ecosystem, we've introduced an experimental `unity_catalog` extension to enable scanning/copying from Delta Lake tables managed by [Unity Catalog](https://www.unitycatalog.io/]).
+For Kuzu users who are entrenched in the data lake ecosystem, we've introduced an experimental `unity_catalog` extension to enable scanning/copying from Delta Lake tables managed by [Unity Catalog](https://www.unitycatalog.io/]).
 
 A quickstart guide on how to setup a local unity catalog server can be found [here](https://docs.unitycatalog.io/quickstart).
 
@@ -43,16 +43,16 @@ LOAD FROM unity.default.numbers
 RETURN *
 ```
 
-One important use case of the Unity Catalog extension is to facilitate seamless data transfer from tables in Unity Catalog to Kùzu.
+One important use case of the Unity Catalog extension is to facilitate seamless data transfer from tables in Unity Catalog to Kuzu.
 ```cypher
-// Migrate data from the unity.default.numbers table to the `numbers` table in Kùzu
+// Migrate data from the unity.default.numbers table to the `numbers` table in Kuzu
 CREATE NODE TABLE numbers (id INT32, score DOUBLE , PRIMARY KEY(id));
 COPY numbers FROM unity.numbers;
 ```
 
-Check out the [docs](https://docs.kuzudb.com/extensions/attach/unity/) for more information on how to use Kùzu with Unity Catalog.
+Check out the [docs](https://docs.kuzudb.com/extensions/attach/unity/) for more information on how to use Kuzu with Unity Catalog.
 Please note that the `unity_catalog` extension is experimental and currently only supports scanning from Delta Lake tables.
-There are numerous upstream issues that are actively being resolved, so if you are using Kùzu with Unity Catalog, do reach
+There are numerous upstream issues that are actively being resolved, so if you are using Kuzu with Unity Catalog, do reach
 to us on [Discord](https://kuzudb.com/chat) and let us know how it's going!
 
 ### Google Cloud Storage (GCS) support
@@ -84,7 +84,7 @@ You can check out the documentation for our GCS feature [here](https://docs.kuzu
 ### Stopwords customization in Full-text Search (FTS)
 Stopwords in full-text search (FTS) are commonly occurring words that are excluded from indexing and query processing to improve efficiency and relevance. Common words like "the", "and", "is", "in", etc. (which can be language-specific), are deemed non-essential for search relevance and are ignored during the index creation step.
 
-By default, Kùzu uses a pre-defined list of common english stopwords. However it's perfectly plausible that you may need to customize the stopwords list to be more useful for your domain and use cases. In v0.8.2, a custom stopword list can be given as an optional parameter when an FTS index is built as follows:
+By default, Kuzu uses a pre-defined list of common english stopwords. However it's perfectly plausible that you may need to customize the stopwords list to be more useful for your domain and use cases. In v0.8.2, a custom stopword list can be given as an optional parameter when an FTS index is built as follows:
 
 ```cypher
 CALL CREATE_FTS_INDEX(
@@ -151,11 +151,11 @@ As can be seen, there is a manyfold improvement in the performance of these quer
 
 ## Closing remarks
 
-With every release of Kùzu, we aim to not only fix bugs and address user issues -- we also strive to continually improve our query processor's performance
+With every release of Kuzu, we aim to not only fix bugs and address user issues -- we also strive to continually improve our query processor's performance
 and our overall usability and developer experience. The GCS support feature was only recently [requested by a user](https://github.com/kuzudb/kuzu/issues/4849)
 and we're excited to see it shipped in rapid time thanks to the hard work of our engineers and interns.
-If you are looking to use Kùzu in a production setting or have a real use case for which a feature is missing, don't be shy,
+If you are looking to use Kuzu in a production setting or have a real use case for which a feature is missing, don't be shy,
 please do reach out on [GitHub](https://github.com/kuzudb/kuzu) and raise an issue!
 
-We always love hearing from our users, so please share your feedback on the latest features and spread the word about Kùzu.
+We always love hearing from our users, so please share your feedback on the latest features and spread the word about Kuzu.
 See you in the next release! 🚀

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -19,7 +19,7 @@ export async function getStaticPaths({ paginate }) {
 const { page } = Astro.props;
 ---
 
-<Base meta_title="Blog - Kùzu">
+<Base meta_title="Blog - Kuzu">
   <Posts posts={page.data} />
   <Pagination
     length={page.lastPage}


### PR DESCRIPTION
Based on an internal discussion, we will be referencing the database name as Kuzu in our blog for ease of communication and discoverability by search engines. The company name is still, officially, Kùzu Inc.