### PR TITLE
Add click benchmarks table

### DIFF
--- a/src/content/post/2025-03-31-kuzu-v-0.9.0.md
+++ b/src/content/post/2025-03-31-kuzu-v-0.9.0.md
@@ -101,10 +101,58 @@ Kuzu now provides both synchronous and asynchronous APIs for Python and Node.js 
 
 Our team has been consistently focusing on improving query performance. In this release, we announce a major improvement on aggregation workloads, including distinct, hash aggregate and aggregate on distinct values. The performance again mainly comes from vectorizing computation and paralleling the final aggregation stage. We will present technical details in a separate blog post.
 
-```
-Show benchmark
-```
+Benchmarks are from [ClickBench](https://github.com/ClickHouse/ClickBench/)'s benchmark suite, converted to cypher and run using a modified version of their benchmarking scripts (which uses our Python API to execute the queries and measures the total runtime of `kuzu.Connection.execute`).
 
+The cold queries are run once with OS caches dropped before each query and in a new process.
+The hot queries are run twice from the same process, database and connection as the cold query and the result is averaged.
+
+The queries were run on a machine with 2x AMD EPYC 7551 (total 64 cores 128 threads) and 512GB RAM.
+
+| Query   | 0.7.1 (cold)   | 0.8.0 (cold)   | 0.8.2 (cold)    | 0.9.0 (cold)     | 0.7.1 (hot)   | 0.8.0 (hot)      | 0.8.2 (hot)      | 0.9.0 (hot)        |
+|---------|----------------|----------------|-----------------|------------------|---------------|------------------|------------------|--------------------|
+| Q1      | 0.0791s        | 0.0534s        | 0.0597s         | 0.0658s          | 0.035s        | 0.0321s          | 0.0297s          | 0.0322s            |
+| Q2      | 0.233s         | 0.248s         | 0.257s          | 0.233s           | 0.0209s       | 0.0196s          | 0.0175s          | 0.0199s            |
+| Q3      | 0.539s         | 0.548s         | 0.538s          | 0.564s           | 0.0414s       | 0.0452s          | 0.0427s          | 0.0474s            |
+| Q4      | 1.06s          | 1.06s          | 1.01s           | 1.02s            | 0.0709s       | 0.074s           | 0.0693s          | 0.0768s            |
+| Q5      | 23.3s          | 23.3s          | 24.3s           | **1.25s** (19x)  | 21s           | 22.1s            | 22.8s            | **0.52s** (44x)    |
+| Q6      | 20.4s          | 20.2s          | 13.6s           | **1.96s** (10x)  | 16.9s         | 17.1s            | 11s              | **0.373s** (46x)   |
+| Q7      | 0.225s         | 0.235s         | 0.228s          | 0.247s           | 0.0192s       | 0.018s           | 0.0143s          | 0.017s             |
+| Q8      | 0.273s         | 0.3s           | 0.285s          | 0.284s           | 0.0247s       | 0.033s           | 0.0361s          | 0.0454s            |
+| Q9      | 201s           | **42.7s** (5x) | **3.51s** (57x) | **2.85s** (71x)  | 196s          | **35.4s** (6x)   | **2.46s** (79x)  | **1.96s** (100x)   |
+| Q10     | 214s           | **51.5s** (4x) | **4.04s** (53x) | **3.25s** (66x)  | 206s          | **47.3s** (4x)   | **2.62s** (79x)  | **1.99s** (104x)   |
+| Q11     | 19.2s          | 10.3s          | **1.87s** (10x) | **1.84s** (10x)  | 15s           | **6.4s** (2x)    | **0.681s** (22x) | **0.633s** (24x)   |
+| Q12     | 32.4s          | **11.6s** (3x) | **2.04s** (16x) | **1.99s** (16x)  | 28.6s         | **6.88s** (4x)   | **0.684s** (42x) | **0.737s** (39x)   |
+| Q13     | 5.47s          | **2.09s** (3x) | **1.96s** (3x)  | **2.05s** (3x)   | 3.58s         | **0.424s** (8x)  | **0.427s** (8x)  | **0.428s** (8x)    |
+| Q14     | 59.3s          | **24.6s** (2x) | **3.19s** (19x) | **3.25s** (18x)  | 53s           | **17.3s** (3x)   | **0.903s** (59x) | **0.879s** (60x)   |
+| Q15     | 5.91s          | **2.44s** (2x) | **2.2s** (3x)   | **2.15s** (3x)   | 4.03s         | **0.458s** (9x)  | **0.46s** (9x)   | **0.446s** (9x)    |
+| Q16     | 7.08s          | **1.57s** (5x) | **1.45s** (5x)  | **1.49s** (5x)   | 5.99s         | **0.75s** (8x)   | **0.747s** (8x)  | **0.749s** (8x)    |
+| Q17     | 11.2s          | **3.2s** (4x)  | **3.04s** (4x)  | **2.92s** (4x)   | 8.36s         | **1.01s** (8x)   | **1.06s** (8x)   | **1.05s** (8x)     |
+| Q18     | 11.4s          | **3.03s** (4x) | **2.98s** (4x)  | **2.94s** (4x)   | 9.13s         | **0.922s** (10x) | **1.06s** (9x)   | **0.947s** (10x)   |
+| Q19     | 28.6s          | **4.47s** (6x) | **4.19s** (7x)  | **4.29s** (7x)   | 21s           | **2.42s** (9x)   | **2.72s** (8x)   | **2.45s** (9x)     |
+| Q20     | 1.01s          | 1.08s          | 0.959s          | 0.976s           | 0.0651s       | 0.0664s          | 0.0651s          | 0.065s             |
+| Q21     | 20s            | 22.7s          | 21.1s           | **4.84s** (5x)   | 20.7s         | 23.6s            | 21.7s            | **0.634s** (37x)   |
+| Q22     | 21.1s          | 23.6s          | 21.8s           | **10.2s** (2x)   | 21s           | 23.6s            | 21.5s            | **0.854s** (28x)   |
+| Q23     | 1.1e+03s       | 1.13e+03s      | **19.1s** (59x) | **10.7s** (106x) | 1.09e+03s     | 1.11e+03s        | **18.5s** (60x)  | **0.949s** (1170x) |
+| Q24     | 33.4s          | 34.2s          | 32.4s           | 24.7s            | 22.5s         | 24.6s            | 23.1s            | **3.24s** (8x)     |
+| Q25     | 2.59s          | 2.55s          | 2.34s           | 2.43s            | 0.0631s       | 0.0647s          | 0.0666s          | 0.0653s            |
+| Q26     | 1.73s          | 1.71s          | 1.52s           | 1.59s            | 0.077s        | 0.0714s          | 0.0838s          | 0.0785s            |
+| Q27     | 2.63s          | 2.51s          | 2.48s           | 2.45s            | 0.0739s       | 0.0717s          | 0.0715s          | 0.0717s            |
+| Q28     | 5.02s          | 5.37s          | 5.38s           | 5.42s            | 0.964s        | 1.01s            | 0.978s           | 0.971s             |
+| Q29     | 4.33s          | 3.37s          | 4.77s           | 3.48s            | 4.01s         | 3.27s            | 4.57s            | 3.25s              |
+| Q30     | hang           | hang           | hang            | hang             | hang          | hang             | hang             | hang               |
+| Q31     | 6.51s          | 3.31s          | **3.08s** (2x)  | **3.21s** (2x)   | 3.47s         | **0.526s** (7x)  | **0.535s** (6x)  | **0.544s** (6x)    |
+| Q32     | 9.26s          | **4.43s** (2x) | **4.04s** (2x)  | **3.87s** (2x)   | 5.36s         | **0.771s** (7x)  | **0.784s** (7x)  | **0.787s** (7x)    |
+| Q33     | 66s            | **8.29s** (8x) | **8.32s** (8x)  | **8.55s** (8x)   | 48.7s         | **6.22s** (8x)   | **6.27s** (8x)   | **6.38s** (8x)     |
+| Q34     | 24.1s          | **6.08s** (4x) | **6.26s** (4x)  | **6.14s** (4x)   | 15.8s         | **1.67s** (9x)   | **1.66s** (10x)  | **1.66s** (10x)    |
+| Q35     | 22.5s          | **6.21s** (4x) | **6.02s** (4x)  | **6.35s** (4x)   | 17.9s         | **1.75s** (10x)  | **1.78s** (10x)  | **1.8s** (10x)     |
+| Q36     | 9.93s          | **1.37s** (7x) | **1.35s** (7x)  | **1.31s** (8x)   | 7.84s         | **0.946s** (8x)  | **0.932s** (8x)  | **0.898s** (9x)    |
+| Q37     | 1.65s          | 1.55s          | 1.5s            | 1.51s            | 0.191s        | 0.111s           | 0.135s           | 0.123s             |
+| Q38     | 1.48s          | 1.42s          | 1.41s           | 1.46s            | 0.0941s       | 0.128s           | 0.126s           | 0.126s             |
+| Q39     | 1.51s          | 1.59s          | 1.52s           | 1.49s            | 0.0834s       | 0.126s           | 0.121s           | 0.135s             |
+| Q40     | 3.1s           | 3.27s          | 3s              | 2.88s            | 0.409s        | 0.32s            | 0.291s           | 0.275s             |
+| Q41     | 0.904s         | 1.01s          | 0.826s          | 0.831s           | 0.0884s       | 0.077s           | 0.0869s          | 0.0937s            |
+| Q42     | 0.768s         | 0.866s         | 0.728s          | 0.762s           | 0.061s        | 0.0786s          | 0.0765s          | 0.0717s            |
+| Q43     | 0.519s         | 0.551s         | 0.474s          | 0.449s           | 0.0533s       | 0.0476s          | 0.055s           | 0.0541s            |
 
 ### Full-text search index creation
 


### PR DESCRIPTION
I was thinking we could add the benchmark queries to the benchmarks directory in the main repo, and include a link to them here (they are a bit long and the table itself is quite large already, so I'm not sure if including them inline is a good idea).

The table is a bit large as I wasn't sure exactly which versions to include. I'm still running benchmarks for 0.8.0, but maybe we should just include one of the 0.8.x vesions, but as there have been significant changes between them in some queries I thought it might be useful to see the differences (it looks like there was only a significant difference in Q5 and Q6 between 0.8.1 and 0.8.2, so maybe 0.8.1 should be omitted, but it might still be useful to include both 0.8.0 and 0.8.2.

I've written a script to generate the table from the data, so please don't make manual changes to it in case it needs to be regenerated. I was also thinking that I should try and generate either bolding or better yet colours (I gather that we can [use latex](https://github.blog/news-insights/product-news/math-support-in-markdown/), so it should be possible to generate highlighting on the numbers based on the difference between the benchmark values).